### PR TITLE
Issue #16: ack callbacks are not always called

### DIFF
--- a/dist/radar_client.js
+++ b/dist/radar_client.js
@@ -63,6 +63,7 @@ function Client(backend) {
       message.userId = this._configuration.userId;
       message.userType = this._configuration.userType;
       message.accountName = this._configuration.accountName;
+      message.userData = this._configuration.userData;
     }
     this.emit('messageAuthenticated', message);
   });
@@ -361,7 +362,7 @@ Client.prototype._sendMessage = function(message) {
     this._socket.sendPacket('message', JSON.stringify(message));
   } else if (this._isConfigured) {
     this._restoreRequired = true;
-    if (!memorized) {
+    if (!memorized || message.ack) {
       this._queuedMessages.push(message);
     }
     this.manager.connectWhenAble();

--- a/lib/radar_client.js
+++ b/lib/radar_client.js
@@ -27,6 +27,7 @@ function Client(backend) {
       message.userId = this._configuration.userId;
       message.userType = this._configuration.userType;
       message.accountName = this._configuration.accountName;
+      message.userData = this._configuration.userData;
     }
     this.emit('messageAuthenticated', message);
   });
@@ -325,7 +326,7 @@ Client.prototype._sendMessage = function(message) {
     this._socket.sendPacket('message', JSON.stringify(message));
   } else if (this._isConfigured) {
     this._restoreRequired = true;
-    if (!memorized) {
+    if (!memorized || message.ack) {
       this._queuedMessages.push(message);
     }
     this.manager.connectWhenAble();

--- a/test/radar_client.unit.test.js
+++ b/test/radar_client.unit.test.js
@@ -144,10 +144,20 @@ exports.RadarClient = {
     'should not queue a presence set, but require restore': function() {
       client.configure({ accountName: 'test', userId: 123, userType: 0 });
       assert.ok(!client.manager.is('activated'));
-      client.set('presence:/test/account/1', 'online', function(){});
+      client.set('presence:/test/account/1', 'online');
       assert.ok(client._restoreRequired);
       assert.ok(!client.manager.is('activated'));
       assert.equal(client._queuedMessages.length, 0);
+      assert.deepEqual(client._presences, { 'presence:/test/account/1': 'online' });
+    },
+
+    'should queue a presence set and require restore if there is a callback': function() {
+      client.configure({ accountName: 'test', userId: 123, userType: 0 });
+      assert.ok(!client.manager.is('activated'));
+      client.set('presence:/test/account/1', 'online', function(){});
+      assert.ok(client._restoreRequired);
+      assert.ok(!client.manager.is('activated'));
+      assert.equal(client._queuedMessages.length, 1);
       assert.deepEqual(client._presences, { 'presence:/test/account/1': 'online' });
     }
   },
@@ -193,17 +203,27 @@ exports.RadarClient = {
     'should not queue a subscribe operation if disconnected, but require restore': function() {
       client.configure({ accountName: 'test', userId: 123, userType: 0 });
       assert.ok(!client.manager.is('activated'));
-      client.subscribe('status:/test/account/1', function(){});
+      client.subscribe('status:/test/account/1');
       assert.ok(client._restoreRequired);
       assert.ok(!client.manager.is('activated'));
       assert.equal(client._queuedMessages.length, 0);
       assert.deepEqual(client._subscriptions, { 'status:/test/account/1': 'subscribe' });
     },
 
+    'should queue a subscribe operation if disconnected and require restore if there is a callback': function() {
+      client.configure({ accountName: 'test', userId: 123, userType: 0 });
+      assert.ok(!client.manager.is('activated'));
+      client.subscribe('status:/test/account/1', function(){});
+      assert.ok(client._restoreRequired);
+      assert.ok(!client.manager.is('activated'));
+      assert.equal(client._queuedMessages.length, 1);
+      assert.deepEqual(client._subscriptions, { 'status:/test/account/1': 'subscribe' });
+    },
+
     'should not queue a sync operation if disconnected, but require restore': function() {
       client.configure({ accountName: 'test', userId: 123, userType: 0 });
       assert.ok(!client.manager.is('activated'));
-      client.sync('presence:/test/account/1', function(){});
+      client.sync('presence:/test/account/1');
       assert.ok(client._restoreRequired);
       assert.ok(!client.manager.is('activated'));
       assert.equal(client._queuedMessages.length, 0);
@@ -232,10 +252,20 @@ exports.RadarClient = {
     'should not queue a message if the subscription was not in memory, but require restore': function() {
       client.configure({ accountName: 'test', userId: 123, userType: 0 });
       assert.ok(!client.manager.is('activated'));
-      client.unsubscribe('presence:/test/account/1', function(){});
+      client.unsubscribe('presence:/test/account/1');
       assert.ok(client._restoreRequired);
       assert.ok(!client.manager.is('activated'));
       assert.equal(client._queuedMessages.length, 0);
+      assert.deepEqual(client._subscriptions, {});
+    },
+
+    'should queue a message if the subscription was not in memory and require restore if there is a callback': function() {
+      client.configure({ accountName: 'test', userId: 123, userType: 0 });
+      assert.ok(!client.manager.is('activated'));
+      client.unsubscribe('presence:/test/account/1', function(){});
+      assert.ok(client._restoreRequired);
+      assert.ok(!client.manager.is('activated'));
+      assert.equal(client._queuedMessages.length, 1);
       assert.deepEqual(client._subscriptions, {});
     }
   },


### PR DESCRIPTION
RadarClient should always call the acknowledgement function if one is
provided, even for a presence or subscription

closes #16 

@vanchi-zendesk 
