### PR TITLE
Issue #25: cancel guard when manager is closed

### DIFF
--- a/dist/radar_client.js
+++ b/dist/radar_client.js
@@ -480,6 +480,10 @@ function create() {
         this.authenticate();
       },
 
+      onclose: function() {
+        this.cancelGuard();
+      },
+
       ondisconnected: function(event, from, to) {
         backoff.increment();
 

--- a/lib/state.js
+++ b/lib/state.js
@@ -50,6 +50,10 @@ function create() {
         this.authenticate();
       },
 
+      onclose: function() {
+        this.cancelGuard();
+      },
+
       ondisconnected: function(event, from, to) {
         backoff.increment();
 

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "mocha": "*"
   },
   "scripts": {
-    "test": "make test"
+    "test": "npm run build && make test",
+    "build": "make build"
   }
 }

--- a/test/state.test.js
+++ b/test/state.test.js
@@ -122,6 +122,15 @@ exports['given a state machine'] = {
 
     machine.connect();
 
+  },
+
+  'closing will cancel the guard timer': function() {
+    machine.open();
+    assert(!machine._guard);
+    machine.connect();
+    assert(machine._guard);
+    machine.close();
+    assert(!machine._guard);
   }
 };
 


### PR DESCRIPTION
- Adds a state machine hook for cancelling the guard when the manager is
  closed.

closes #25 

@zendesk/zendesk-radar 
