### PR TITLE
Expose current user id in a simple way

### DIFF
--- a/dist/radar_client.js
+++ b/dist/radar_client.js
@@ -147,6 +147,10 @@ Client.prototype.configuration = function(name) {
   return name in this._configuration ? JSON.parse(JSON.stringify(this._configuration[name])) : null;
 };
 
+Client.prototype.currentUserId = function() {
+  return this._configuration && this._configuration.userId;
+};
+
 Client.prototype.currentClientId = function() {
   return this._socket && this._socket.id;
 };

--- a/lib/radar_client.js
+++ b/lib/radar_client.js
@@ -107,6 +107,10 @@ Client.prototype.configuration = function(name) {
   return name in this._configuration ? JSON.parse(JSON.stringify(this._configuration[name])) : null;
 };
 
+Client.prototype.currentUserId = function() {
+  return this._configuration && this._configuration.userId;
+};
+
 Client.prototype.currentClientId = function() {
   return this._socket && this._socket.id;
 };


### PR DESCRIPTION
Nothing special here, just trying to avoid the overhead from `.configuration('userId')`

/cc @zendesk/zendesk-radar
### Steps to merge
- [x] :+1: of the team
### Risks
- None
