### PR TITLE
Radar-403: Client changes for stream resource

### DIFF
--- a/dist/radar_client.js
+++ b/dist/radar_client.js
@@ -179,6 +179,16 @@ Client.prototype.stream = function(scope) {
   return new Scope('stream:/'+this._configuration.accountName+'/'+scope, this);
 };
 
+Client.prototype.push = function(scope, resource, action, value, callback) {
+  return this._write({
+    op: 'push',
+    to: scope,
+    resource: resource,
+    action: action,
+    value: value
+  }, callback);
+};
+
 Client.prototype.set = function(scope, value, callback) {
   return this._write({
     op: 'set',
@@ -197,8 +207,14 @@ Client.prototype.publish = function(scope, value, callback) {
   }, callback);
 };
 
-Client.prototype.subscribe = function(scope, callback) {
-  return this._write({ op: 'subscribe', to: scope }, callback);
+Client.prototype.subscribe = function(scope, options, callback) {
+  var message = { op: 'subscribe', to: scope };
+  if (typeof options == 'function') {
+    callback = options;
+  } else {
+    message.options = options;
+  }
+  return this._write(message, callback);
 };
 
 Client.prototype.unsubscribe = function(scope, callback) {
@@ -465,7 +481,7 @@ module.exports = Client;
   this.client = client;
 }
 
-var props = [ 'set', 'get', 'subscribe', 'unsubscribe', 'publish', 'sync',
+var props = [ 'set', 'get', 'subscribe', 'unsubscribe', 'publish', 'push', 'sync',
   'on', 'once', 'when', 'removeListener', 'removeAllListeners'];
 
 var init = function(name) {

--- a/lib/radar_client.js
+++ b/lib/radar_client.js
@@ -139,6 +139,16 @@ Client.prototype.stream = function(scope) {
   return new Scope('stream:/'+this._configuration.accountName+'/'+scope, this);
 };
 
+Client.prototype.push = function(scope, resource, action, value, callback) {
+  return this._write({
+    op: 'push',
+    to: scope,
+    resource: resource,
+    action: action,
+    value: value
+  }, callback);
+};
+
 Client.prototype.set = function(scope, value, callback) {
   return this._write({
     op: 'set',
@@ -157,8 +167,14 @@ Client.prototype.publish = function(scope, value, callback) {
   }, callback);
 };
 
-Client.prototype.subscribe = function(scope, callback) {
-  return this._write({ op: 'subscribe', to: scope }, callback);
+Client.prototype.subscribe = function(scope, options, callback) {
+  var message = { op: 'subscribe', to: scope };
+  if (typeof options == 'function') {
+    callback = options;
+  } else {
+    message.options = options;
+  }
+  return this._write(message, callback);
 };
 
 Client.prototype.unsubscribe = function(scope, callback) {

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -3,7 +3,7 @@ function Scope(prefix, client) {
   this.client = client;
 }
 
-var props = [ 'set', 'get', 'subscribe', 'unsubscribe', 'publish', 'sync',
+var props = [ 'set', 'get', 'subscribe', 'unsubscribe', 'publish', 'push', 'sync',
   'on', 'once', 'when', 'removeListener', 'removeAllListeners'];
 
 var init = function(name) {


### PR DESCRIPTION
Adds the stream resource operations to the client
1. Ability to create RadarClient.stream('xyz')
2. Supports:
   - standard features: subscribe/unsubscribe/sync/get
   - push(resource, action, value): add a message to the end of the stream with specific options.
   - get({ from: id }) - Ability to get the messages from a specific id onwards.
   - subscribe({ from: id}) - Ability to subscribe at a given id. All the messages in the list after the id will be resend to the client. This brings support for replaying missed notifications if you remember the last message id you received.
     /cc @zendesk/zendesk-radar
### Steps to merge
- [x] :+1: of the team
### References
- Jira link: https://zendesk.atlassian.net/browse/RADAR-403
### Risks
- Low: None of this code is used, but watch for regression.
