### PR TITLE
Step two of changes to store client data on server:

### DIFF
--- a/dist/radar_client.js
+++ b/dist/radar_client.js
@@ -515,7 +515,7 @@ Client.prototype._identitySet = function () {
   // Send msg that associates this.id with current name
   var association = { id : socket.id, name: this.name };
   var clientVersion = getClientVersion();
-  var message = { op : 'name_id_sync', to: 'server', value: association,
+  var message = { op : 'name_id_sync', to: 'control:client_name', value: association,
                                             client_version: clientVersion};
   this._write(message);
 };

--- a/dist/radar_client.js
+++ b/dist/radar_client.js
@@ -28,7 +28,7 @@ module.exports = Backoff;
 },
 "lib/client_version.js": function(module, exports, require){// Auto-generated file, overwritten by scripts/add_package_version.js
 
-function getClientVersion() { return '0.13.1'; };
+function getClientVersion() { return '0.13.1'; }
 
 module.exports = getClientVersion;},
 "lib/index.js": function(module, exports, require){var Client = require('./radar_client'),
@@ -504,7 +504,7 @@ Client.prototype._uuidV4Generate = function () {
     lut[d1&0xff]+lut[d1>>8&0xff]+'-'+lut[d1>>16&0x0f|0x40]+lut[d1>>24&0xff]+'-'+
     lut[d2&0x3f|0x80]+lut[d2>>8&0xff]+'-'+lut[d2>>16&0xff]+lut[d2>>24&0xff]+
     lut[d3&0xff]+lut[d3>>8&0xff]+lut[d3>>16&0xff]+lut[d3>>24&0xff];
-}
+};
 
 Client.prototype._identitySet = function () {
   var socket = this._socket;
@@ -518,7 +518,7 @@ Client.prototype._identitySet = function () {
   var message = { op : 'name_id_sync', to: 'server', value: association,
                                             client_version: clientVersion};
   this._write(message);
-}
+};
 
 Client.setBackend = function(lib) { eio = lib; };
 
@@ -707,6 +707,9 @@ M.prototype = {
   removeAllListeners: function(ev) {
     if(!ev) { this._events = {}; }
     else { this._events[ev] && (this._events[ev] = []); }
+  },
+  listeners: function(ev) {
+    return (this._events ? this._events[ev] || [] : []);
   },
   emit: function(ev) {
     this._events || (this._events = {});

--- a/dist/radar_client.js
+++ b/dist/radar_client.js
@@ -45,8 +45,6 @@ var MicroEE = require('microee'),
     immediate = typeof setImmediate != 'undefined' ? setImmediate :
                                     function(fn) { setTimeout(fn, 1); };
 
-MicroEE.mixin(Client);
-
 function Client(backend) {
   var self = this;
   this.logger = require('minilog')('radar_client');
@@ -66,6 +64,8 @@ function Client(backend) {
   // Allow backend substitution for tests
   this.backend = backend || eio;
 }
+
+MicroEE.mixin(Client);
 
 // Public API
 
@@ -324,7 +324,7 @@ Client.prototype._batch = function(message) {
     time = message.value[index + 1];
 
     if (time > current) {
-      this.emitNext(message.to, data);
+      this._emitNext(message.to, data);
     }
     if (time > newest) {
       newest = time;
@@ -381,6 +381,16 @@ Client.prototype._createManager = function() {
   });
 
   manager.on('activate', function() {
+    var socket = client._socket;
+    if (!client.name) {
+      client.name = socket.id;
+    }
+
+    // Send msg that associates client.id with current name
+    association = { id : socket.id, name: client.name };
+    message = { op : 'name_id_sync', to: 'server', value: association };
+    socket && socket.send(JSON.stringify(message));
+
     client._restore();
     client.emit('ready');
   });
@@ -425,7 +435,6 @@ Client.prototype._restore = function() {
   if (this._restoreRequired) {
     this._restoreRequired = false;
 
-
     for (to in this._subscriptions) {
       if (this._subscriptions.hasOwnProperty(to)) {
         item = this._subscriptions[to];
@@ -455,7 +464,7 @@ Client.prototype._sendMessage = function(message) {
   this.emit('message:out', message);
 
   if (this._socket && this.manager.is('activated')) {
-    this._socket.sendPacket('message', JSON.stringify(message));
+    this._socket.send(JSON.stringify(message));
   } else if (this._isConfigured) {
     this._restoreRequired = true;
     if (!memorized || message.ack) {
@@ -472,19 +481,19 @@ Client.prototype._messageReceived = function (msg) {
     case 'err':
     case 'ack':
     case 'get':
-      this.emitNext(message.op, message);
+      this._emitNext(message.op, message);
       break;
     case 'sync':
       this._batch(message);
       break;
     default:
-      this.emitNext(message.to, message);
+      this._emitNext(message.to, message);
   }
 };
 
-Client.prototype.emitNext = function() {
+Client.prototype._emitNext = function() {
   var args = Array.prototype.slice.call(arguments), client = this;
-  immediate(function(){ client.emit.apply(client, args); });
+  immediate(function() { client.emit.apply(client, args); });
 };
 
 Client.setBackend = function(lib) { eio = lib; };

--- a/lib/client_version.js
+++ b/lib/client_version.js
@@ -1,5 +1,5 @@
 // Auto-generated file, overwritten by scripts/add_package_version.js
 
-function getClientVersion() { return '0.13.1'; };
+function getClientVersion() { return '0.13.1'; }
 
 module.exports = getClientVersion;

--- a/lib/client_version.js
+++ b/lib/client_version.js
@@ -1,0 +1,5 @@
+// Auto-generated file, overwritten by scripts/add_package_version.js
+
+function getClientVersion() { return '0.13.1'; };
+
+module.exports = getClientVersion;

--- a/lib/radar_client.js
+++ b/lib/radar_client.js
@@ -6,8 +6,6 @@ var MicroEE = require('microee'),
     immediate = typeof setImmediate != 'undefined' ? setImmediate :
                                     function(fn) { setTimeout(fn, 1); };
 
-MicroEE.mixin(Client);
-
 function Client(backend) {
   var self = this;
   this.logger = require('minilog')('radar_client');
@@ -27,6 +25,8 @@ function Client(backend) {
   // Allow backend substitution for tests
   this.backend = backend || eio;
 }
+
+MicroEE.mixin(Client);
 
 // Public API
 
@@ -285,7 +285,7 @@ Client.prototype._batch = function(message) {
     time = message.value[index + 1];
 
     if (time > current) {
-      this.emitNext(message.to, data);
+      this._emitNext(message.to, data);
     }
     if (time > newest) {
       newest = time;
@@ -342,6 +342,16 @@ Client.prototype._createManager = function() {
   });
 
   manager.on('activate', function() {
+    var socket = client._socket;
+    if (!client.name) {
+      client.name = socket.id;
+    }
+
+    // Send msg that associates client.id with current name
+    association = { id : socket.id, name: client.name };
+    message = { op : 'name_id_sync', to: 'server', value: association };
+    socket && socket.send(JSON.stringify(message));
+
     client._restore();
     client.emit('ready');
   });
@@ -386,7 +396,6 @@ Client.prototype._restore = function() {
   if (this._restoreRequired) {
     this._restoreRequired = false;
 
-
     for (to in this._subscriptions) {
       if (this._subscriptions.hasOwnProperty(to)) {
         item = this._subscriptions[to];
@@ -416,7 +425,7 @@ Client.prototype._sendMessage = function(message) {
   this.emit('message:out', message);
 
   if (this._socket && this.manager.is('activated')) {
-    this._socket.sendPacket('message', JSON.stringify(message));
+    this._socket.send(JSON.stringify(message));
   } else if (this._isConfigured) {
     this._restoreRequired = true;
     if (!memorized || message.ack) {
@@ -433,19 +442,19 @@ Client.prototype._messageReceived = function (msg) {
     case 'err':
     case 'ack':
     case 'get':
-      this.emitNext(message.op, message);
+      this._emitNext(message.op, message);
       break;
     case 'sync':
       this._batch(message);
       break;
     default:
-      this.emitNext(message.to, message);
+      this._emitNext(message.to, message);
   }
 };
 
-Client.prototype.emitNext = function() {
+Client.prototype._emitNext = function() {
   var args = Array.prototype.slice.call(arguments), client = this;
-  immediate(function(){ client.emit.apply(client, args); });
+  immediate(function() { client.emit.apply(client, args); });
 };
 
 Client.setBackend = function(lib) { eio = lib; };

--- a/lib/radar_client.js
+++ b/lib/radar_client.js
@@ -460,7 +460,7 @@ Client.prototype._uuidV4Generate = function () {
     lut[d1&0xff]+lut[d1>>8&0xff]+'-'+lut[d1>>16&0x0f|0x40]+lut[d1>>24&0xff]+'-'+
     lut[d2&0x3f|0x80]+lut[d2>>8&0xff]+'-'+lut[d2>>16&0xff]+lut[d2>>24&0xff]+
     lut[d3&0xff]+lut[d3>>8&0xff]+lut[d3>>16&0xff]+lut[d3>>24&0xff];
-}
+};
 
 Client.prototype._identitySet = function () {
   var socket = this._socket;
@@ -474,7 +474,7 @@ Client.prototype._identitySet = function () {
   var message = { op : 'name_id_sync', to: 'server', value: association,
                                             client_version: clientVersion};
   this._write(message);
-}
+};
 
 Client.setBackend = function(lib) { eio = lib; };
 

--- a/lib/radar_client.js
+++ b/lib/radar_client.js
@@ -471,7 +471,7 @@ Client.prototype._identitySet = function () {
   // Send msg that associates this.id with current name
   var association = { id : socket.id, name: this.name };
   var clientVersion = getClientVersion();
-  var message = { op : 'name_id_sync', to: 'server', value: association,
+  var message = { op : 'name_id_sync', to: 'control:client_name', value: association,
                                             client_version: clientVersion};
   this._write(message);
 };

--- a/lib/radar_client.js
+++ b/lib/radar_client.js
@@ -4,7 +4,8 @@ var MicroEE = require('microee'),
     Scope = require('./scope.js'),
     StateMachine = require('./state.js'),
     immediate = typeof setImmediate != 'undefined' ? setImmediate :
-                                    function(fn) { setTimeout(fn, 1); };
+                                    function(fn) { setTimeout(fn, 1); },
+    getClientVersion = require('./client_version.js');
 
 function Client(backend) {
   var self = this;
@@ -342,16 +343,7 @@ Client.prototype._createManager = function() {
   });
 
   manager.on('activate', function() {
-    var socket = client._socket;
-    if (!client.name) {
-      client.name = socket.id;
-    }
-
-    // Send msg that associates client.id with current name
-    association = { id : socket.id, name: client.name };
-    message = { op : 'name_id_sync', to: 'server', value: association };
-    socket && socket.send(JSON.stringify(message));
-
+    client._identitySet();
     client._restore();
     client.emit('ready');
   });
@@ -456,6 +448,33 @@ Client.prototype._emitNext = function() {
   var args = Array.prototype.slice.call(arguments), client = this;
   immediate(function() { client.emit.apply(client, args); });
 };
+
+// Variant (by Jeff Ward) of code behind node-uuid, but avoids need for module
+var lut = []; for (var i=0; i<256; i++) { lut[i] = (i<16?'0':'')+(i).toString(16); }
+Client.prototype._uuidV4Generate = function () {
+  var d0 = Math.random()*0xffffffff|0;
+  var d1 = Math.random()*0xffffffff|0;
+  var d2 = Math.random()*0xffffffff|0;
+  var d3 = Math.random()*0xffffffff|0;
+  return lut[d0&0xff]+lut[d0>>8&0xff]+lut[d0>>16&0xff]+lut[d0>>24&0xff]+'-'+
+    lut[d1&0xff]+lut[d1>>8&0xff]+'-'+lut[d1>>16&0x0f|0x40]+lut[d1>>24&0xff]+'-'+
+    lut[d2&0x3f|0x80]+lut[d2>>8&0xff]+'-'+lut[d2>>16&0xff]+lut[d2>>24&0xff]+
+    lut[d3&0xff]+lut[d3>>8&0xff]+lut[d3>>16&0xff]+lut[d3>>24&0xff];
+}
+
+Client.prototype._identitySet = function () {
+  var socket = this._socket;
+  if (!this.name) {
+    this.name = this._uuidV4Generate();
+  }
+
+  // Send msg that associates this.id with current name
+  var association = { id : socket.id, name: this.name };
+  var clientVersion = getClientVersion();
+  var message = { op : 'name_id_sync', to: 'server', value: association,
+                                            client_version: clientVersion};
+  this._write(message);
+}
 
 Client.setBackend = function(lib) { eio = lib; };
 

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "pretest": "npm run build",
     "test": "ls ./tests/*.test.js | xargs -n 1 -t -I {} sh -c 'TEST=\"{}\" npm run test-one'",
     "test-one": "./node_modules/.bin/mocha --ui exports --reporter spec --slow 2000ms --bail \"$TEST\"",
+    "test-one-solo": "./node_modules/.bin/mocha --ui exports --reporter spec --slow 2000ms --bail",
     "prebuild": "npm run check-modules",
     "version-build": "node scripts/add_client_version.js",
     "build": "npm run version-build; ./node_modules/gluejs/bin/gluejs --include ./lib --npm microee,sfsm --replace engine.io-client=eio,minilog=Minilog --global RadarClient --main lib/index.js --out dist/radar_client.js"

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "test": "ls ./tests/*.test.js | xargs -n 1 -t -I {} sh -c 'TEST=\"{}\" npm run test-one'",
     "test-one": "./node_modules/.bin/mocha --ui exports --reporter spec --slow 2000ms --bail \"$TEST\"",
     "prebuild": "npm run check-modules",
-    "build": "./node_modules/gluejs/bin/gluejs --include ./lib --npm microee,sfsm --replace engine.io-client=eio,minilog=Minilog --global RadarClient --main lib/index.js --out dist/radar_client.js"
+    "version-build": "node scripts/add_client_version.js",
+    "build": "npm run version-build; ./node_modules/gluejs/bin/gluejs --include ./lib --npm microee,sfsm --replace engine.io-client=eio,minilog=Minilog --global RadarClient --main lib/index.js --out dist/radar_client.js"
   }
 }

--- a/readme.md
+++ b/readme.md
@@ -18,5 +18,5 @@ See http://radar.zendesk.com/ for detailed documentation.
 
 ## Copyright and License
 
-Copyright 2012, Zendesk Inc.
+Copyright 2015, Zendesk Inc.
 Licensed under the Apache License Version 2.0, http://www.apache.org/licenses/LICENSE-2.0

--- a/scripts/add_client_version.js
+++ b/scripts/add_client_version.js
@@ -5,12 +5,12 @@ var version = require('../package.json').version,
 var FILEPATH = 'lib/client_version.js';
 
 // Create the string to write
-var fileContents = '// Auto-generated file, overwritten by'
-                    + ' scripts/add_package_version.js\n\n'
-                    + 'function getClientVersion() { return \''
-                    + version
-                    + '\'; };\n\n'
-                    + 'module.exports = getClientVersion;';
+var fileContents = '// Auto-generated file, overwritten by' +
+                    ' scripts/add_package_version.js\n\n' +
+                    'function getClientVersion() { return \'' +
+                    version +
+                    '\'; }\n\n' +
+                    'module.exports = getClientVersion;';
 
 // Rewrite the file lib/version.js to contain a current getVersion()
 if (fs.exists(FILEPATH)) {
@@ -21,5 +21,5 @@ if (fs.exists(FILEPATH)) {
 var stream = fs.createWriteStream(FILEPATH);
 stream.once('open', function () {
   stream.write(fileContents);
-  stream.end()
+  stream.end();
 });

--- a/scripts/add_client_version.js
+++ b/scripts/add_client_version.js
@@ -1,0 +1,25 @@
+// Add the package version to radar_client.js prior to building dist
+var version = require('../package.json').version,
+    fs = require('fs');
+
+var FILEPATH = 'lib/client_version.js';
+
+// Create the string to write
+var fileContents = '// Auto-generated file, overwritten by'
+                    + ' scripts/add_package_version.js\n\n'
+                    + 'function getClientVersion() { return \''
+                    + version
+                    + '\'; };\n\n'
+                    + 'module.exports = getClientVersion;';
+
+// Rewrite the file lib/version.js to contain a current getVersion()
+if (fs.exists(FILEPATH)) {
+  fs.unlinkSync(FILEPATH);
+}
+
+// Write the client version to a new instance of the file
+var stream = fs.createWriteStream(FILEPATH);
+stream.once('open', function () {
+  stream.write(fileContents);
+  stream.end()
+});

--- a/tests/lib/engine.js
+++ b/tests/lib/engine.js
@@ -9,7 +9,7 @@ function Socket() {
 
 MicroEE.mixin(Socket);
 
-Socket.prototype.sendPacket = function(nop, data) {
+Socket.prototype.send = function(data) {
   var message = JSON.parse(data);
   current._written.push(message);
   log(message);

--- a/tests/radar_client.alloc.test.js
+++ b/tests/radar_client.alloc.test.js
@@ -32,7 +32,7 @@ exports['given an instance of Radar client'] = {
 
     client.on('ready', function() {
       assert.equal(MockEngine.current._written[0].op, 'name_id_sync');
-      assert.equal(MockEngine.current._written[0].to, 'server');
+      assert.equal(MockEngine.current._written[0].to, 'control:client_name');
       done();
     });
   },

--- a/tests/radar_client.alloc.test.js
+++ b/tests/radar_client.alloc.test.js
@@ -1,6 +1,7 @@
 var assert = require('assert'),
     MockEngine = require('./lib/engine.js'),
     RadarClient = require('../lib/radar_client.js'),
+    getClientVersion = require('../lib/client_version.js'),
     client;
 
 RadarClient.setBackend(MockEngine);
@@ -14,10 +15,36 @@ exports['given an instance of Radar client'] = {
     MockEngine.current._written = [];
   },
 
+  'client version is always available': function(done) {
+    assert.ok(getClientVersion());
+    done();
+  },
+
   'calls to operations do not cause errors before the client is configured, but dont write either': function(done) {
     client.status('test/foo').set('bar');
     assert.equal(MockEngine.current._written.length, 0);
     done();
+  },
+
+  'as long as the client is configured, name_id_sync is the first message sent': function(done) {
+    client.configure({ userId: 123, accountName: 'dev' });
+    client.status('test/foo').set('bar');
+
+    client.on('ready', function() {
+      assert.equal(MockEngine.current._written[0].op, 'name_id_sync');
+      assert.equal(MockEngine.current._written[0].to, 'server');
+      done();
+    });
+  },
+
+  'as long as the client is configured, client name is set': function(done) {
+    client.configure({ userId: 123, accountName: 'dev' });
+    client.status('test/foo').set('bar');
+
+    client.on('ready', function() {
+      assert.ok(client.name);
+      done();
+    });
   },
 
   'as long as the client is configured, any operation that requires a send will automatically connect': function(done) {

--- a/tests/radar_client.alloc.test.js
+++ b/tests/radar_client.alloc.test.js
@@ -25,7 +25,7 @@ exports['given an instance of Radar client'] = {
     client.status('test/foo').set('bar');
 
     client.on('ready', function() {
-      assert.equal(MockEngine.current._written.length, 1);
+      assert.equal(MockEngine.current._written.length, 2);
       done();
     });
   },

--- a/tests/radar_client.test.js
+++ b/tests/radar_client.test.js
@@ -71,7 +71,7 @@ exports['after reconnecting'] = {
 
     client.once('connect', function() {
       connected = true;
-      assert.equal(MockEngine.current._written.length, 0);
+      assert.equal(MockEngine.current._written.length, 1);
       assert.equal(client._queuedMessages.length, 1);
       assert.deepEqual(client._queuedMessages[0], {
         op: 'set',

--- a/tests/radar_client.unit.test.js
+++ b/tests/radar_client.unit.test.js
@@ -802,12 +802,21 @@ exports.RadarClient = {
         },
 
         'activate': {
-          'and emits "ready"': function() {
+          'and emits "authenticateMessage", "ready"': function() {
             var called = false;
+            var count = 0;
 
             client.emit = function(name) {
               called = true;
-              assert.equal(name, 'ready');
+
+              count++;
+              if (count == 1) {
+                assert.equal(name, 'authenticateMessage');
+              }
+
+              if (count == 2) {
+                assert.equal(name, 'ready');
+              }
             };
 
             client._createManager();

--- a/tests/radar_client.unit.test.js
+++ b/tests/radar_client.unit.test.js
@@ -527,7 +527,7 @@ exports.RadarClient = {
         client._restoreRequired = true;
         client.configure({ accountName: 'foo', userId: 123, userType: 2 });
         client.alloc('test', function() {
-          assert.equal(MockEngine.current._written.length, 2);
+          assert.equal(MockEngine.current._written.length, 3);
           assert.ok(MockEngine.current._written.some(function(message) {
             return (message.op == 'set' &&
               message.to == 'presence:/foo/bar' &&
@@ -548,7 +548,7 @@ exports.RadarClient = {
         client._restoreRequired = true;
         client.configure({ accountName: 'foo', userId: 123, userType: 2 });
         client.alloc('test', function() {
-          assert.equal(MockEngine.current._written.length, 2);
+          assert.equal(MockEngine.current._written.length, 3);
           assert.ok(MockEngine.current._written.some(function(message) {
             return (message.op == 'subscribe' &&
               message.to == 'status:/foo/bar');
@@ -661,7 +661,7 @@ exports.RadarClient = {
 
         client._channelSyncTimes.you = now - HOUR;
 
-        client.emitNext = function(name, data) {
+        client._emitNext = function(name, data) {
           called = true;
           assert.equal(name, message.to);
           assert.deepEqual(data, JSON.parse(message.value[0]));
@@ -811,6 +811,7 @@ exports.RadarClient = {
             };
 
             client._createManager();
+            client.manager.emit('connect');
             client.manager.emit('activate');
             assert.ok(called);
           },
@@ -833,6 +834,7 @@ exports.RadarClient = {
             };
 
             client._createManager();
+            client.manager.emit('connect');
             client.manager.emit('activate');
           }
         },
@@ -853,16 +855,15 @@ exports.RadarClient = {
     },
 
     '._sendMessage': {
-      'should call sendPacket() on the _socket if the manager is activated': function() {
+      'should call send() on the _socket if the manager is activated': function() {
         var called = false,
             message = { test: 1 };
 
         client.manager.is = function(state) { return state == 'activated'; };
 
         client._socket = {
-          sendPacket: function(name, data) {
+          send: function(data) {
             called = true;
-            assert.equal(name, 'message');
             assert.equal(data, JSON.stringify(message));
           }
         };
@@ -897,7 +898,7 @@ exports.RadarClient = {
               },
               json = JSON.stringify(message);
 
-          client.emitNext = function(name, data) {
+          client._emitNext = function(name, data) {
             if (name === 'message:in') return;
             called = true;
             assert.equal(name, message.op);
@@ -915,7 +916,7 @@ exports.RadarClient = {
               },
               json = JSON.stringify(message);
 
-          client.emitNext = function(name, data) {
+          client._emitNext = function(name, data) {
             if (name === 'message:in') return;
             called = true;
             assert.equal(name, message.op);
@@ -933,7 +934,7 @@ exports.RadarClient = {
               },
               json = JSON.stringify(message);
 
-          client.emitNext = function(name, data) {
+          client._emitNext = function(name, data) {
             if (name === 'message:in') return;
             called = true;
             assert.equal(name, message.op);
@@ -968,7 +969,7 @@ exports.RadarClient = {
               },
               json = JSON.stringify(message);
 
-          client.emitNext = function(name, data) {
+          client._emitNext = function(name, data) {
             if (name === 'message:in') return;
 
             called = true;


### PR DESCRIPTION
Current changes include:

  - use send(string) instead of sendPacket('message', string), as sendPacket is private to engine.io
  - send *name_id_sync* message to server
  - rename emitNext to _emitNext
  - update copyright year in readme
  - changes to tests to accommodate new message, and changes from sendPacket() to send(), emitNext() to _emitNext()

/cc @zendesk/zendesk-radar

### Steps to merge
 - [ ] :+1: of the team
 - [ ] :+1: new tests

### References
 - Jira link: https://zendesk.atlassian.net/browse/RADAR-463

### Risks
 - Low: new client-side functionality is added, but current client-side functionality is not being removed in this step