### PR TITLE
Client side changes for sending a UUID as client name

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,4 @@ notifications:
   flowdock:
     secure: GzhfVfSDKQtvfCaHHh2AYTLn/kWOUvHK+SM44AfWX10pwQXCicSR5kx7jMIDrU//0+T2CP/m1EJDnK15CTix+vRJLTwybgc4b8NOl0XmnZXVcW+4i8uhKnXA3bm6+dgVxvUCwNy69dbk7H7CkyFZOzJcZCVliiRBZcbj41uwMqc=
 branches:
-  only: [master, staging, production]
+  only: [master, staging, production, /^pobrien\/.*$/]

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,4 @@ notifications:
   flowdock:
     secure: GzhfVfSDKQtvfCaHHh2AYTLn/kWOUvHK+SM44AfWX10pwQXCicSR5kx7jMIDrU//0+T2CP/m1EJDnK15CTix+vRJLTwybgc4b8NOl0XmnZXVcW+4i8uhKnXA3bm6+dgVxvUCwNy69dbk7H7CkyFZOzJcZCVliiRBZcbj41uwMqc=
 branches:
-  only: [master, staging, production, /^pobrien\/.*$/]
+  only: [master, staging, production, pobrien/server_side_client_state]

--- a/dist/radar_client.js
+++ b/dist/radar_client.js
@@ -26,6 +26,11 @@ Backoff.prototype.isUnavailable = function() {
 
 module.exports = Backoff;
 },
+"lib/client_version.js": function(module, exports, require){// Auto-generated file, overwritten by scripts/add_package_version.js
+
+function getClientVersion() { return '0.13.1'; };
+
+module.exports = getClientVersion;},
 "lib/index.js": function(module, exports, require){var Client = require('./radar_client'),
     instance = new Client(),
     Backoff = require('./backoff.js');
@@ -43,9 +48,8 @@ var MicroEE = require('microee'),
     Scope = require('./scope.js'),
     StateMachine = require('./state.js'),
     immediate = typeof setImmediate != 'undefined' ? setImmediate :
-                                    function(fn) { setTimeout(fn, 1); };
-
-MicroEE.mixin(Client);
+                                    function(fn) { setTimeout(fn, 1); },
+    getClientVersion = require('./client_version.js');
 
 function Client(backend) {
   var self = this;
@@ -66,6 +70,8 @@ function Client(backend) {
   // Allow backend substitution for tests
   this.backend = backend || eio;
 }
+
+MicroEE.mixin(Client);
 
 // Public API
 
@@ -381,6 +387,7 @@ Client.prototype._createManager = function() {
   });
 
   manager.on('activate', function() {
+    client._identitySet();
     client._restore();
     client.emit('ready');
   });
@@ -485,6 +492,32 @@ Client.prototype._messageReceived = function (msg) {
 Client.prototype.emitNext = function() {
   var args = Array.prototype.slice.call(arguments), client = this;
   immediate(function(){ client.emit.apply(client, args); });
+};
+
+Client.prototype._identitySet = function () {
+  if (!this.name) {
+    this.name = this._uuidV4Generate();
+  }
+
+  // Send msg that associates this.id with current name
+  var association = { id : this._socket.id, name: this.name };
+  var clientVersion = getClientVersion();
+  var message = { op : 'name_id_sync', to: 'control:/client_name', value: association,
+    client_version: clientVersion};
+  this._write(message);
+}; 
+
+// Variant (by Jeff Ward) of code behind node-uuid, but avoids need for module
+var lut = []; for (var i=0; i<256; i++) { lut[i] = (i<16?'0':'')+(i).toString(16); }
+Client.prototype._uuidV4Generate = function () {
+  var d0 = Math.random()*0xffffffff|0;
+  var d1 = Math.random()*0xffffffff|0;
+  var d2 = Math.random()*0xffffffff|0;
+  var d3 = Math.random()*0xffffffff|0;
+  return lut[d0&0xff]+lut[d0>>8&0xff]+lut[d0>>16&0xff]+lut[d0>>24&0xff]+'-'+
+    lut[d1&0xff]+lut[d1>>8&0xff]+'-'+lut[d1>>16&0x0f|0x40]+lut[d1>>24&0xff]+'-'+
+    lut[d2&0x3f|0x80]+lut[d2>>8&0xff]+'-'+lut[d2>>16&0xff]+lut[d2>>24&0xff]+
+    lut[d3&0xff]+lut[d3>>8&0xff]+lut[d3>>16&0xff]+lut[d3>>24&0xff];
 };
 
 Client.setBackend = function(lib) { eio = lib; };
@@ -674,6 +707,9 @@ M.prototype = {
   removeAllListeners: function(ev) {
     if(!ev) { this._events = {}; }
     else { this._events[ev] && (this._events[ev] = []); }
+  },
+  listeners: function(ev) {
+    return (this._events ? this._events[ev] || [] : []);
   },
   emit: function(ev) {
     this._events || (this._events = {});

--- a/lib/client_version.js
+++ b/lib/client_version.js
@@ -1,0 +1,5 @@
+// Auto-generated file, overwritten by scripts/add_package_version.js
+
+function getClientVersion() { return '0.13.1'; };
+
+module.exports = getClientVersion;

--- a/lib/radar_client.js
+++ b/lib/radar_client.js
@@ -4,9 +4,8 @@ var MicroEE = require('microee'),
     Scope = require('./scope.js'),
     StateMachine = require('./state.js'),
     immediate = typeof setImmediate != 'undefined' ? setImmediate :
-                                    function(fn) { setTimeout(fn, 1); };
-
-MicroEE.mixin(Client);
+                                    function(fn) { setTimeout(fn, 1); },
+    getClientVersion = require('./client_version.js');
 
 function Client(backend) {
   var self = this;
@@ -27,6 +26,8 @@ function Client(backend) {
   // Allow backend substitution for tests
   this.backend = backend || eio;
 }
+
+MicroEE.mixin(Client);
 
 // Public API
 
@@ -342,6 +343,7 @@ Client.prototype._createManager = function() {
   });
 
   manager.on('activate', function() {
+    client._identitySet();
     client._restore();
     client.emit('ready');
   });
@@ -446,6 +448,32 @@ Client.prototype._messageReceived = function (msg) {
 Client.prototype.emitNext = function() {
   var args = Array.prototype.slice.call(arguments), client = this;
   immediate(function(){ client.emit.apply(client, args); });
+};
+
+Client.prototype._identitySet = function () {
+  if (!this.name) {
+    this.name = this._uuidV4Generate();
+  }
+
+  // Send msg that associates this.id with current name
+  var association = { id : this._socket.id, name: this.name };
+  var clientVersion = getClientVersion();
+  var message = { op : 'name_id_sync', to: 'control:/client_name', value: association,
+    client_version: clientVersion};
+  this._write(message);
+}; 
+
+// Variant (by Jeff Ward) of code behind node-uuid, but avoids need for module
+var lut = []; for (var i=0; i<256; i++) { lut[i] = (i<16?'0':'')+(i).toString(16); }
+Client.prototype._uuidV4Generate = function () {
+  var d0 = Math.random()*0xffffffff|0;
+  var d1 = Math.random()*0xffffffff|0;
+  var d2 = Math.random()*0xffffffff|0;
+  var d3 = Math.random()*0xffffffff|0;
+  return lut[d0&0xff]+lut[d0>>8&0xff]+lut[d0>>16&0xff]+lut[d0>>24&0xff]+'-'+
+    lut[d1&0xff]+lut[d1>>8&0xff]+'-'+lut[d1>>16&0x0f|0x40]+lut[d1>>24&0xff]+'-'+
+    lut[d2&0x3f|0x80]+lut[d2>>8&0xff]+'-'+lut[d2>>16&0xff]+lut[d2>>24&0xff]+
+    lut[d3&0xff]+lut[d3>>8&0xff]+lut[d3>>16&0xff]+lut[d3>>24&0xff];
 };
 
 Client.setBackend = function(lib) { eio = lib; };

--- a/package.json
+++ b/package.json
@@ -47,7 +47,9 @@
     "pretest": "npm run build",
     "test": "ls ./tests/*.test.js | xargs -n 1 -t -I {} sh -c 'TEST=\"{}\" npm run test-one'",
     "test-one": "./node_modules/.bin/mocha --ui exports --reporter spec --slow 2000ms --bail \"$TEST\"",
+    "test-one-solo": "./node_modules/.bin/mocha --ui exports --reporter spec --slow 2000ms --bail",
     "prebuild": "npm run check-modules",
-    "build": "./node_modules/gluejs/bin/gluejs --include ./lib --npm microee,sfsm --replace engine.io-client=eio,minilog=Minilog --global RadarClient --main lib/index.js --out dist/radar_client.js"
+    "build": "npm run version-build; ./node_modules/gluejs/bin/gluejs --include ./lib --npm microee,sfsm --replace engine.io-client=eio,minilog=Minilog --global RadarClient --main lib/index.js --out dist/radar_client.js",
+    "version-build": "node scripts/add_client_version.js"
   }
 }

--- a/scripts/add_client_version.js
+++ b/scripts/add_client_version.js
@@ -1,0 +1,25 @@
+// Add the package version to radar_client.js prior to building dist
+var version = require('../package.json').version,
+    fs = require('fs');
+
+var FILEPATH = 'lib/client_version.js';
+
+// Create the string to write
+var fileContents = '// Auto-generated file, overwritten by'
+                    + ' scripts/add_package_version.js\n\n'
+                    + 'function getClientVersion() { return \''
+                    + version
+                    + '\'; };\n\n'
+                    + 'module.exports = getClientVersion;';
+
+// Rewrite the file lib/version.js to contain a current getVersion()
+if (fs.exists(FILEPATH)) {
+  fs.unlinkSync(FILEPATH);
+}
+
+// Write the client version to a new instance of the file
+var stream = fs.createWriteStream(FILEPATH);
+stream.once('open', function () {
+  stream.write(fileContents);
+  stream.end()
+});

--- a/tests/radar_client.alloc.test.js
+++ b/tests/radar_client.alloc.test.js
@@ -1,6 +1,7 @@
 var assert = require('assert'),
     MockEngine = require('./lib/engine.js'),
     RadarClient = require('../lib/radar_client.js'),
+    getClientVersion = require('../lib/client_version.js'),
     client;
 
 RadarClient.setBackend(MockEngine);
@@ -14,10 +15,36 @@ exports['given an instance of Radar client'] = {
     MockEngine.current._written = [];
   },
 
+  'client version is always available': function(done) {
+    assert.ok(getClientVersion());
+    done();
+  },
+
   'calls to operations do not cause errors before the client is configured, but dont write either': function(done) {
     client.status('test/foo').set('bar');
     assert.equal(MockEngine.current._written.length, 0);
     done();
+  },
+
+  'as long as the client is configured, name_id_sync is the first message sent': function(done) {
+    client.configure({ userId: 123, accountName: 'dev' });
+    client.status('test/foo').set('bar');
+
+    client.on('ready', function() {
+      assert.equal(MockEngine.current._written[0].op, 'name_id_sync');
+      assert.equal(MockEngine.current._written[0].to, 'control:/client_name');
+      done();
+    });
+  },
+
+  'as long as the client is configured, client name is set': function(done) {
+    client.configure({ userId: 123, accountName: 'dev' });
+    client.status('test/foo').set('bar');
+
+    client.on('ready', function() {
+      assert.ok(client.name);
+      done();
+    });
   },
 
   'as long as the client is configured, any operation that requires a send will automatically connect': function(done) {
@@ -25,7 +52,7 @@ exports['given an instance of Radar client'] = {
     client.status('test/foo').set('bar');
 
     client.on('ready', function() {
-      assert.equal(MockEngine.current._written.length, 1);
+      assert.equal(MockEngine.current._written.length, 2);
       done();
     });
   },

--- a/tests/radar_client.test.js
+++ b/tests/radar_client.test.js
@@ -71,7 +71,7 @@ exports['after reconnecting'] = {
 
     client.once('connect', function() {
       connected = true;
-      assert.equal(MockEngine.current._written.length, 0);
+      assert.equal(MockEngine.current._written.length, 1);
       assert.equal(client._queuedMessages.length, 1);
       assert.deepEqual(client._queuedMessages[0], {
         op: 'set',

--- a/tests/radar_client.unit.test.js
+++ b/tests/radar_client.unit.test.js
@@ -527,7 +527,7 @@ exports.RadarClient = {
         client._restoreRequired = true;
         client.configure({ accountName: 'foo', userId: 123, userType: 2 });
         client.alloc('test', function() {
-          assert.equal(MockEngine.current._written.length, 2);
+          assert.equal(MockEngine.current._written.length, 3);
           assert.ok(MockEngine.current._written.some(function(message) {
             return (message.op == 'set' &&
               message.to == 'presence:/foo/bar' &&
@@ -548,7 +548,7 @@ exports.RadarClient = {
         client._restoreRequired = true;
         client.configure({ accountName: 'foo', userId: 123, userType: 2 });
         client.alloc('test', function() {
-          assert.equal(MockEngine.current._written.length, 2);
+          assert.equal(MockEngine.current._written.length, 3);
           assert.ok(MockEngine.current._written.some(function(message) {
             return (message.op == 'subscribe' &&
               message.to == 'status:/foo/bar');
@@ -802,15 +802,25 @@ exports.RadarClient = {
         },
 
         'activate': {
-          'and emits "ready"': function() {
+          'and emits "authenticateMessage", "ready"': function() {
             var called = false;
+            var count = 0;
 
             client.emit = function(name) {
               called = true;
-              assert.equal(name, 'ready');
+
+              count++;
+              if (1 == count) {
+                assert.equal(name, 'authenticateMessage');
+              }
+
+              if (2 == count) {
+                assert.equal(name, 'ready');
+              }
             };
 
             client._createManager();
+            client.manager.emit('connect');
             client.manager.emit('activate');
             assert.ok(called);
           },
@@ -833,6 +843,7 @@ exports.RadarClient = {
             };
 
             client._createManager();
+            client.manager.emit('connect');
             client.manager.emit('activate');
           }
         },


### PR DESCRIPTION
- generate client UUID, and send to server along with client version
- add a script to generate getClientVersion() and its source file
- modify existing tests to accommodate new name_id_sync message
- add new tests for name_id_sync message

/cc @zendesk/zendesk-radar

### Steps to merge
 - [ ] :+1: of the team

### References
 - Jira link: https://zendesk.atlassian.net/browse/RADAR-471

### Risks
 - Low to None: server doesn't yet process the name_id_sync message