### PR TITLE
Add control scope, and nameSync method, and modify some existing tests

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,9 @@
+### 0.14.0
+* Code changes to support server side client state
+  - generate client UUID; send to server as client name
+  - auto-generate getClientVersion() and its source file
+  - add nameSync method and new *control* scope
+
 ### 0.13.1
 * Code cleanup
   - comment capitalization, comment line length, code line length

--- a/dist/radar_client.js
+++ b/dist/radar_client.js
@@ -174,6 +174,21 @@ Client.prototype.stream = function(scope) {
   return new Scope('stream:/'+this._configuration.accountName+'/'+scope, this);
 };
 
+// Access the "control" chainable operations
+Client.prototype.control = function(scope) {
+  return new Scope('control:/'+this._configuration.accountName+'/'+scope, this);
+};
+
+Client.prototype.nameSync = function(scope, options, callback) {
+  var message = { op: 'nameSync', to: scope };
+  if (typeof options == 'function') {
+    callback = options;
+  } else {
+    message.options = options;
+  }
+  return this._write(message, callback);
+};
+
 Client.prototype.push = function(scope, resource, action, value, callback) {
   return this._write({
     op: 'push',
@@ -502,9 +517,9 @@ Client.prototype._identitySet = function () {
   // Send msg that associates this.id with current name
   var association = { id : this._socket.id, name: this.name };
   var clientVersion = getClientVersion();
-  var message = { op : 'name_id_sync', to: 'control:/client_name', value: association,
-    client_version: clientVersion};
-  this._write(message);
+  var options = { association: association, clientVersion: clientVersion };
+
+  this.control('clientName').nameSync(options);
 }; 
 
 // Variant (by Jeff Ward) of code behind node-uuid, but avoids need for module
@@ -530,7 +545,7 @@ module.exports = Client;
 }
 
 var props = [ 'set', 'get', 'subscribe', 'unsubscribe', 'publish', 'push', 'sync',
-  'on', 'once', 'when', 'removeListener', 'removeAllListeners'];
+  'on', 'once', 'when', 'removeListener', 'removeAllListeners', 'nameSync'];
 
 var init = function(name) {
   Scope.prototype[name] = function () {

--- a/lib/radar_client.js
+++ b/lib/radar_client.js
@@ -130,6 +130,21 @@ Client.prototype.stream = function(scope) {
   return new Scope('stream:/'+this._configuration.accountName+'/'+scope, this);
 };
 
+// Access the "control" chainable operations
+Client.prototype.control = function(scope) {
+  return new Scope('control:/'+this._configuration.accountName+'/'+scope, this);
+};
+
+Client.prototype.nameSync = function(scope, options, callback) {
+  var message = { op: 'nameSync', to: scope };
+  if (typeof options == 'function') {
+    callback = options;
+  } else {
+    message.options = options;
+  }
+  return this._write(message, callback);
+};
+
 Client.prototype.push = function(scope, resource, action, value, callback) {
   return this._write({
     op: 'push',
@@ -458,9 +473,9 @@ Client.prototype._identitySet = function () {
   // Send msg that associates this.id with current name
   var association = { id : this._socket.id, name: this.name };
   var clientVersion = getClientVersion();
-  var message = { op : 'name_id_sync', to: 'control:/client_name', value: association,
-    client_version: clientVersion};
-  this._write(message);
+  var options = { association: association, clientVersion: clientVersion };
+
+  this.control('clientName').nameSync(options);
 }; 
 
 // Variant (by Jeff Ward) of code behind node-uuid, but avoids need for module

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -4,7 +4,7 @@ function Scope(prefix, client) {
 }
 
 var props = [ 'set', 'get', 'subscribe', 'unsubscribe', 'publish', 'push', 'sync',
-  'on', 'once', 'when', 'removeListener', 'removeAllListeners'];
+  'on', 'once', 'when', 'removeListener', 'removeAllListeners', 'nameSync'];
 
 var init = function(name) {
   Scope.prototype[name] = function () {

--- a/tests/radar_client.alloc.test.js
+++ b/tests/radar_client.alloc.test.js
@@ -26,13 +26,13 @@ exports['given an instance of Radar client'] = {
     done();
   },
 
-  'as long as the client is configured, name_id_sync is the first message sent': function(done) {
+  'as long as the client is configured, nameSync is the first message sent': function(done) {
     client.configure({ userId: 123, accountName: 'dev' });
     client.status('test/foo').set('bar');
 
     client.on('ready', function() {
-      assert.equal(MockEngine.current._written[0].op, 'name_id_sync');
-      assert.equal(MockEngine.current._written[0].to, 'control:/client_name');
+      assert.equal(MockEngine.current._written[0].op, 'nameSync');
+      assert.equal(MockEngine.current._written[0].to, 'control:/dev/clientName');
       done();
     });
   },


### PR DESCRIPTION
Replace the raw *name_id_sync* message with *nameSync*

/cc @zendesk/zendesk-radar

### Steps to merge
 - [ ] :+1: of the team

### References
 - Jira link: https://zendesk.atlassian.net/browse/RADAR-497

### Risks
 - Low: this is just a repackaging of the existing *name_id_sync* message