### PR TITLE
reset sync point on unsubscribe for message lists

### DIFF
--- a/dist/radar_client.js
+++ b/dist/radar_client.js
@@ -426,6 +426,9 @@ Client.prototype._memorize = function(message) {
       if (this._subscriptions[message.to]) {
         delete this._subscriptions[message.to];
       }
+      if (this._channelSyncTimes[message.to]) {
+        delete this._channelSyncTimes[message.to];
+      }
       return true;
     case 'sync':
     case 'subscribe':

--- a/lib/radar_client.js
+++ b/lib/radar_client.js
@@ -382,6 +382,9 @@ Client.prototype._memorize = function(message) {
       if (this._subscriptions[message.to]) {
         delete this._subscriptions[message.to];
       }
+      if (this._channelSyncTimes[message.to]) {
+        delete this._channelSyncTimes[message.to];
+      }
       return true;
     case 'sync':
     case 'subscribe':


### PR DESCRIPTION
@zendesk/zendesk-radar @shajith 

This resets the sync point for message list resource (for chat) so that an unsubscribe and a sync will get you a full history again.
