### PR TITLE
Second implementation of message library for client

### DIFF
--- a/dist/radar_client.js
+++ b/dist/radar_client.js
@@ -184,7 +184,6 @@ Request.prototype.getVersion = function () {
 
 // Private methods
 
-// scope = 'presence:/this/ticket/1'
 Request.prototype._isValid = function () {
   if (!this.message.op || !this.message.to) {
     return false;

--- a/lib/message_request.js
+++ b/lib/message_request.js
@@ -25,24 +25,17 @@ Request.buildGet = function (scope, options) {
 
 Request.buildPublish = function (scope, value) {
   var request = new Request('publish', scope);
-  if (value) {
-    request.message.value = value;
-
-    return request;
-  }
+  request.setAttr('value', value);
+  return request;
 };
 
 Request.buildPush = function (scope, resource, action, value) {
   var request = new Request('push', scope);
-  if (resource && action && value) {
-    request.message.resource = resource;
-    request.message.action = action;
-    request.message.value = value;
+  request.setAttr('resource', resource);
+  request.setAttr('action', action);
+  request.setAttr('value', value);
 
-    return request;
-  } else {
-    throw new Error('Invalid push request message.');
-  }
+  return request;
 };
 
 Request.buildNameSync = function (scope, options) {
@@ -51,16 +44,13 @@ Request.buildNameSync = function (scope, options) {
 
 Request.buildSet = function (scope, value, clientData, key, userType) {
   var request = new Request('set', scope);
-  if (value) {
-    request.message.value = value;
-    request.message.key = key;
-    request.message.type= userType;
-    if (typeof(clientData) != 'function') {
-      request.message.clientData = clientData;
-    }
-
-    return request;
+  request.setAttr('value', value);
+  request._setAttrOptionalDefined('key', key);
+  request._setAttrOptionalUndefined('type', userType);
+  if (typeof(clientData) != 'function') {
+    request._setAttrOptionalUndefined('clientData', clientData);
   }
+  return request;
 };
 
 Request.buildSync = function (scope, options) {
@@ -73,34 +63,6 @@ Request.buildSubscribe = function (scope, options) {
 
 Request.buildUnsubscribe = function (scope, options) {
   return new Request('unsubscribe', scope);
-};
-
-Request.prototype.getMessage = function () {
-  return this.message;
-};
-
-Request.prototype.setOptions = function (options) {
-  if (options && typeof options != 'function') {
-    this.message.options = options;
-  }
-
-  return this;
-};
-
-Request.prototype.setOptionsVersion = function (version) {
-  if (this.options) {
-    this.options.version = version;
-  } else {
-    this.options = { version: version };
-  }
-};
-
-Request.prototype.isOptionsSet = function () {
-  return !!this.message.options;
-};
-
-Request.prototype.isPresence = function () {
-  return this.type === 'presence';
 };
 
 // TO DO: config class should return the required data via getters
@@ -118,31 +80,66 @@ Request.setAuthData = function (message, configuration) {
   }
 };
 
-Request.getAck = function (message) {
-  return (message && message.ack);
+Request.getAttr = function (message, attr) {
+  return (message && message[attr]);
 };
 
-Request.getOp = function (message) {
-  return (message && message.op);
+Request.setAttr = function (message, attr, value) {
+  if (message && attr) { message[attr] = value; }
 };
 
-Request.getTo = function (message) {
-  return (message && message.to);
+// Instance methods
+
+Request.prototype.getMessage = function () {
+  return this.message;
 };
 
-Request.getValue = function (message) {
-  return (message && message.value);
+Request.prototype.setOptions = function (options) {
+  if (options && typeof options != 'function') {
+    this.message.options = options;
+    this.version = 2;
+  } else {
+    this.version = 1;
+  }
+
+  return this;
 };
 
-Request.getTime = function (message) {
-  return (message && message.time);
+Request.prototype.isPresence = function () {
+  return this.type === 'presence';
 };
 
-Request.setAck = function (message, ack) {
-  if (message && ack) { message.ack = ack; }
+Request.prototype._setAttrOptionalUndefined = function (keyName, keyValue) {
+  if (keyName) {
+    this.message[keyName] = keyValue;
+  }
 };
 
-// scope = 'presence:/this/ticket/1'
+Request.prototype._setAttrOptionalDefined = function (keyName, keyValue) {
+  if (keyName && keyValue) {
+    this.message[keyName] = keyValue;
+  }
+};
+
+Request.prototype.setAttr = function (keyName, keyValue) {
+  if (!keyName || !keyValue) {
+    throw new Error('Invalid request attribute');
+  }
+  this.message[keyName] = keyValue;
+};
+
+Request.prototype.getAttr = function (keyName) {
+  if (keyName) {
+    return this.message[keyName];
+  }
+};
+
+Request.prototype.getVersion = function () {
+  return this.version;
+};
+
+// Private methods
+
 Request.prototype._isValid = function () {
   if (!this.message.op || !this.message.to) {
     return false;

--- a/lib/message_request.js
+++ b/lib/message_request.js
@@ -1,0 +1,176 @@
+var logger = require('minilog')('message:request');
+
+var opTable = {
+  control: ['nameSync'],
+  message: ['publish', 'subscribe', 'sync', 'unsubscribe'],
+  presence: ['get', 'set', 'subscribe', 'sync', 'unsubscribe'],
+  status: ['get', 'set', 'subscribe', 'sync', 'unsubscribe'],
+  stream: ['get', 'push', 'subscribe', 'sync']
+};
+
+var Request = function (operation, scope) {
+  this.message = {
+    op: operation,
+    to: scope
+  };
+
+  if (!this._isValid()) {
+    throw new Error('Invalid request message.');
+  }
+};
+
+Request.buildGet = function (scope, options) {
+  return new Request('get', scope).setOptions(options);
+};
+
+Request.buildPublish = function (scope, value) {
+  var request = new Request('publish', scope);
+  if (value) {
+    request.message.value = value;
+
+    return request;
+  }
+};
+
+Request.buildPush = function (scope, resource, action, value) {
+  var request = new Request('push', scope);
+  if (resource && action && value) {
+    request.message.resource = resource;
+    request.message.action = action;
+    request.message.value = value;
+
+    return request;
+  } else {
+    throw new Error('Invalid push request message.');
+  }
+};
+
+Request.buildNameSync = function (scope, options) {
+  return new Request('nameSync', scope).setOptions(options);
+};
+
+Request.buildSet = function (scope, value, clientData, key, userType) {
+  var request = new Request('set', scope);
+  if (value) {
+    request.message.value = value;
+    request.message.key = key;
+    request.message.type= userType;
+    if (typeof(clientData) != 'function') {
+      request.message.clientData = clientData;
+    }
+
+    return request;
+  }
+};
+
+Request.buildSync = function (scope, options) {
+  return new Request('sync', scope).setOptions(options);
+};
+
+Request.buildSubscribe = function (scope, options) {
+  return new Request('subscribe', scope).setOptions(options);
+};
+
+Request.buildUnsubscribe = function (scope, options) {
+  return new Request('unsubscribe', scope);
+};
+
+Request.prototype.getMessage = function () {
+  return this.message;
+};
+
+Request.prototype.setOptions = function (options) {
+  if (options && typeof options != 'function') {
+    this.message.options = options;
+  }
+
+  return this;
+};
+
+Request.prototype.setOptionsVersion = function (version) {
+  if (this.options) {
+    this.options.version = version;
+  } else {
+    this.options = { version: version };
+  }
+};
+
+Request.prototype.isOptionsSet = function () {
+  return !!this.message.options;
+};
+
+Request.prototype.isPresence = function () {
+  return this.type === 'presence';
+};
+
+// TO DO: config class should return the required data via getters
+Request.setUserData = function (message, configuration) {
+  message.userData = configuration && configuration.userData;
+};
+
+// TO DO: config class should return the required data via getters
+Request.setAuthData = function (message, configuration) {
+  if (configuration && configuration.auth) {
+    message.auth = configuration.auth;
+    message.userId = configuration.userId;
+    message.userType = configuration.userType;
+    message.accountName = configuration.accountName;
+  }
+};
+
+Request.getAck = function (message) {
+  return (message && message.ack);
+};
+
+Request.getOp = function (message) {
+  return (message && message.op);
+};
+
+Request.getTo = function (message) {
+  return (message && message.to);
+};
+
+Request.getValue = function (message) {
+  return (message && message.value);
+};
+
+Request.getTime = function (message) {
+  return (message && message.time);
+};
+
+Request.setAck = function (message, ack) {
+  if (message && ack) { message.ack = ack; }
+};
+
+// scope = 'presence:/this/ticket/1'
+Request.prototype._isValid = function () {
+  if (!this.message.op || !this.message.to) {
+    return false;
+  }
+
+  var type = this._getType();
+  if (type) {
+    this.type = type;
+    return this._isValidType(type) && this._isValidOperation(type);
+  }
+  return false;
+};
+
+Request.prototype._isValidType = function () {
+  var types = Object.keys(opTable);
+  for (var i = 0; i < types.length; i++) {
+    if (types[i] === this.type) { return true; }
+  }
+  return false;
+};
+
+Request.prototype._isValidOperation = function () {
+  var ops = opTable[this.type];
+  return ops && ops.indexOf(this.message.op) >= 0;
+};
+
+Request.prototype._getType = function () {
+  return this.message.to.substring(0, this.message.to.indexOf(':'));
+};
+
+module.exports = Request;

--- a/lib/message_request.js
+++ b/lib/message_request.js
@@ -65,13 +65,22 @@ Request.buildUnsubscribe = function (scope, options) {
   return new Request('unsubscribe', scope);
 };
 
+Request.prototype.setAuthData = function (configuration) {
+  if (configuration && configuration.auth) {
+    this.setAttr('auth', configuration.auth);
+    this.setAttr('userId', configuration.userId);
+    this.setAttr('userType', configuration.userType);
+    this.setAttr('accountName', configuration.accountName);
+  }
+};
+
 // TO DO: config class should return the required data via getters
-Request.setUserData = function (message, configuration) {
+Request.setUserData_old = function (message, configuration) {
   message.userData = configuration && configuration.userData;
 };
 
 // TO DO: config class should return the required data via getters
-Request.setAuthData = function (message, configuration) {
+Request.setAuthData_old = function (message, configuration) {
   if (configuration && configuration.auth) {
     message.auth = configuration.auth;
     message.userId = configuration.userId;
@@ -84,9 +93,11 @@ Request.getAttr = function (message, attr) {
   return (message && message[attr]);
 };
 
+/*
 Request.setAttr = function (message, attr, value) {
   if (message && attr) { message[attr] = value; }
 };
+*/
 
 // Instance methods
 
@@ -163,6 +174,7 @@ Request.prototype._isValidType = function () {
 
 Request.prototype._isValidOperation = function () {
   var ops = opTable[this.type];
+
   return ops && ops.indexOf(this.message.op) >= 0;
 };
 

--- a/lib/message_response.js
+++ b/lib/message_response.js
@@ -1,0 +1,49 @@
+var logger = require('minilog')('message:response');
+
+var Response = function (message, requestMessage) {
+  this.message = message;
+  this.requestMessage = requestMessage;
+
+  if (!this.isValid()) {
+    throw new Error('Invalid response message.');
+  }
+};
+
+Response.parse = function (data, requestMessage) {
+  if (data) {
+    return new Response(data, requestMessage);
+  }
+};
+
+Response.prototype.getMessage = function () {
+  return this.message;
+};
+
+Response.prototype.isValid = function () {
+  // TO DO: validate *value* ?
+  if (this.message.op === 'ack') {
+    return this.message.value === this.requestMessage.ack;
+  }
+  else {
+    return this.message.op && this.message.to &&
+            this.message.to === this.requestMessage.to;
+  }
+};
+
+Response.prototype.forceV2Presence = function () {
+  // Sync v1 for presence scopes is inconsistent: the result should be a 'get'
+  // message, but instead is an 'online' message.  Take a v2 response and
+  // massage it to v1 format prior to returning to the caller.
+  var message = this.message, value = {}, userId;
+  for (userId in message.value) {
+    if (message.value.hasOwnProperty(userId)) {
+      // Skip when not defined; causes exception in FF for 'Work Offline'
+      if (!message.value[userId]) { continue; }
+      value[userId] = message.value[userId].userType;
+    }
+  }
+  message.value = value;
+  message.op = 'online';
+};
+
+module.exports = Response;

--- a/lib/message_response.js
+++ b/lib/message_response.js
@@ -15,6 +15,12 @@ Response.parse = function (data, requestMessage) {
   }
 };
 
+Response.getAttr = function (message, attr) {
+  return message && message[attr];
+};
+
+// Instance methods
+
 Response.prototype.getMessage = function () {
   return this.message;
 };

--- a/lib/message_response.js
+++ b/lib/message_response.js
@@ -1,39 +1,47 @@
 var logger = require('minilog')('message:response');
 
-var Response = function (message, requestMessage) {
-  this.message = message;
-  this.requestMessage = requestMessage;
-
-  if (!this.isValid()) {
-    throw new Error('Invalid response message.');
+function Response (message) {
+  if (typeof(message) === 'string') {
+    this.message = JSON.parse(message);
+  } else {
+    this.message = message;
   }
-};
-
-Response.parse = function (data, requestMessage) {
-  if (data) {
-    return new Response(data, requestMessage);
-  }
-};
+  this.validate();
+}
 
 Response.getAttr = function (message, attr) {
   return message && message[attr];
 };
 
-// Instance methods
-
 Response.prototype.getMessage = function () {
   return this.message;
 };
 
-Response.prototype.isValid = function () {
-  // TO DO: validate *value* ?
-  if (this.message.op === 'ack') {
-    return this.message.value === this.requestMessage.ack;
+Response.prototype.validate = function () {
+  if (!this.message.op) {
+    _throwError('missing op');
   }
-  else {
-    return this.message.op && this.message.to &&
-            this.message.to === this.requestMessage.to;
+
+  switch(this.message.op) {
+    case 'ack':
+      if (!this.message.value) { _throwError('missing value'); }
+      break;
+
+    default:
+      if (this.message.op != 'err' && !this.message.to) { _throwError('missing to'); }
   }
+};
+
+Response.prototype.isValid = function (request) {
+  if (this.getAttr('op') === 'ack') {
+    return this.getAttr('value') === request.getAttr('ack');
+  } else {
+    return this.getAttr('to') === request.getAttr('to');
+  }
+};
+
+Response.prototype.getAttr = function (attr) {
+  return this.message[attr];
 };
 
 Response.prototype.forceV2Presence = function () {
@@ -50,6 +58,10 @@ Response.prototype.forceV2Presence = function () {
   }
   message.value = value;
   message.op = 'online';
+};
+
+var _throwError = function (errMessage) {
+  throw new Error('response: ' + errMessage);
 };
 
 module.exports = Response;

--- a/lib/radar_client.js
+++ b/lib/radar_client.js
@@ -142,30 +142,36 @@ Client.prototype.control = function(scope) {
 // Operations
 
 Client.prototype.nameSync = function(scope, options, callback) {
-  return this._write(Request.buildNameSync(scope, options).getMessage(), callback);
+  var request = Request.buildNameSync(scope, options);
+  return this._write(request.getMessage(), callback);
 };
 
 Client.prototype.push = function(scope, resource, action, value, callback) {
-  return this._write(Request.buildPush(scope, resource, action, value).getMessage(), callback);
+  var request = Request.buildPush(scope, resource, action, value);
+  return this._write(request.getMessage(), callback);
 };
 
 Client.prototype.set = function(scope, value, clientData, callback) {
   callback = callbackSet(callback, clientData);
-  return this._write(Request.buildSet(scope, value, clientData,
-          this._configuration.userId, this._configuration.userType).getMessage(), callback);
+  var request = Request.buildSet(scope, value, clientData,
+                  this._configuration.userId, this._configuration.userType);
+  return this._write(request.getMessage(), callback);
 };
 
 Client.prototype.publish = function(scope, value, callback) {
-  return this._write(Request.buildPublish(scope, value).getMessage(), callback);
+  var request = Request.buildPublish(scope, value);
+  return this._write(request.getMessage(), callback);
 };
 
 Client.prototype.subscribe = function(scope, options, callback) {
   callback = callbackSet(callback, options);
-  return this._write(Request.buildSubscribe(scope, options).getMessage(), callback);
+  var request = Request.buildSubscribe(scope, options);
+  return this._write(request.getMessage(), callback);
 };
 
 Client.prototype.unsubscribe = function(scope, callback) {
-  return this._write(Request.buildUnsubscribe(scope).getMessage(), callback);
+  var request = Request.buildUnsubscribe(scope);
+  return this._write(request.getMessage(), callback);
 };
 
 var callbackSet = function (callback, options) {
@@ -181,7 +187,9 @@ Client.prototype.sync = function (scope, options, callback) {
   var whenCallback = function (data) {
     response = Response.parse(data, request.getMessage());
     if (response) {
-      if (!request.isOptionsSet()) { response.forceV2Presence(); }
+      if (request.getVersion() === 1 && request.isPresence()) {
+        response.forceV2Presence();
+      }
       if (callback) {
         callback(response.getMessage());
       }
@@ -191,9 +199,6 @@ Client.prototype.sync = function (scope, options, callback) {
   };
 
   callback = callbackSet(callback, options);
-  if (!request.isOptionsSet() && request.isPresence()) {
-    request.setOptionsVersion(2);
-  }
   this.when('get', whenCallback);
 
   // sync does not return ACK (it sends back a data message)
@@ -248,7 +253,7 @@ Client.prototype._write = function(message, callback) {
   var self = this;
 
   if (callback) {
-    Request.setAck(message, this._ackCounter++);
+    Request.setAttr(message, 'ack', this._ackCounter++);
 
     // Wait ack
     this.when('ack', function(data) {
@@ -263,31 +268,10 @@ Client.prototype._write = function(message, callback) {
   return this;
 };
 
-/*
-Client.prototype._write_new = function(request, callback) {
-  var self = this;
-
-  if (callback) {
-    request.setAck(this._ackCounter++);
-
-    // Wait ack
-    this.when('ack', function(data) {
-      self.logger().debug('ack', data);
-      if (!Response.parse(data, request)) { return false; }
-      callback(request.getMessage());
-
-      return true;
-    });
-  }
-  this.emit('authenticateMessage', request);
-  return this;
-};
-*/
-
 Client.prototype._batch = function(message) {
-  var to = Request.getTo(message),
-      value = Request.getValue(message),
-      time = Request.getTime(message);
+  var to = Response.getAttr(message, 'to'),
+      value = Response.getAttr(message, 'value'),
+      time = Response.getAttr(message, 'time');
 
   if (!to || !value || !time) {
     return false;
@@ -378,9 +362,9 @@ Client.prototype._createManager = function() {
 // Memorize subscriptions and presence states; return "true" for a message that
 // adds to the memorized subscriptions or presences
 Client.prototype._memorize = function(message) {
-  var op = Request.getOp(message),
-      to = Request.getTo(message),
-      value = Request.getValue(message);
+  var op = Request.getAttr(message, 'op'),
+      to = Request.getAttr(message, 'to'),
+      value = Request.getAttr(message, 'value');
 
   switch(op) {
     case 'unsubscribe':
@@ -439,7 +423,7 @@ Client.prototype._restore = function() {
 
 Client.prototype._sendMessage = function(message) {
   var memorized = this._memorize(message),
-      ack = Request.getAck(message);
+      ack = Request.getAttr(message, 'ack');
 
   this.emit('message:out', message);
 
@@ -456,8 +440,8 @@ Client.prototype._sendMessage = function(message) {
 
 Client.prototype._messageReceived = function (msg) {
   var message = JSON.parse(msg),
-      op = Request.getOp(message),
-      to = Request.getTo(message);
+      op = Response.getAttr(message, 'op'),
+      to = Response.getAttr(message, 'to');
 
   this.emit('message:in', message);
 

--- a/lib/radar_client.js
+++ b/lib/radar_client.js
@@ -178,33 +178,23 @@ Client.prototype.sync = function (scope, options, callback) {
   var request = Request.buildSync(scope, options),
       response;
 
+  var whenCallback = function (data) {
+    response = Response.parse(data, request.getMessage());
+    if (response) {
+      if (!request.isOptionsSet()) { response.forceV2Presence(); }
+      if (callback) {
+        callback(response.getMessage());
+      }
+      return true;
+    }
+    return false;
+  };
+
   callback = callbackSet(callback, options);
   if (!request.isOptionsSet() && request.isPresence()) {
     request.setOptionsVersion(2);
-    this.when('get', function (data) {
-      response = Response.parse(data, request.getMessage());
-      if (response) {
-        // force v2 presence
-        response.forceV2Presence();
-        if (callback) {
-          callback(response.getMessage());
-        }
-        return true;
-      }
-      return false;
-    });
-  } else {
-    this.when('get', function (data) {
-      response = Response.parse(data, request.getMessage());
-      if (response) {
-        if (callback) {
-          callback(response.getMessage());
-        }
-        return true;
-      }
-      return false;
-    });
   }
+  this.when('get', whenCallback);
 
   // sync does not return ACK (it sends back a data message)
   return this._write(request.getMessage());
@@ -215,8 +205,7 @@ Client.prototype.get = function (scope, options, callback) {
   var request = Request.buildGet(scope, options),
       response;
 
-  callback = callbackSet(callback, options);
-  this.when('get', function (data) {
+  var whenCallback = function (data) {
     response = Response.parse(data, request.getMessage());
     if (response) {
       if (callback) {
@@ -225,7 +214,10 @@ Client.prototype.get = function (scope, options, callback) {
       return true;
     }
     return false;
-  });
+  };
+
+  callback = callbackSet(callback, options);
+  this.when('get', whenCallback);
 
   // get does not return ACK (it sends back a data message)
   return this._write(request.getMessage());

--- a/lib/radar_client.js
+++ b/lib/radar_client.js
@@ -143,35 +143,35 @@ Client.prototype.control = function(scope) {
 
 Client.prototype.nameSync = function(scope, options, callback) {
   var request = Request.buildNameSync(scope, options);
-  return this._write(request.getMessage(), callback);
+  return this._write(request, callback);
 };
 
 Client.prototype.push = function(scope, resource, action, value, callback) {
   var request = Request.buildPush(scope, resource, action, value);
-  return this._write(request.getMessage(), callback);
+  return this._write(request, callback);
 };
 
 Client.prototype.set = function(scope, value, clientData, callback) {
   callback = callbackSet(callback, clientData);
   var request = Request.buildSet(scope, value, clientData,
                   this._configuration.userId, this._configuration.userType);
-  return this._write(request.getMessage(), callback);
+  return this._write(request, callback);
 };
 
 Client.prototype.publish = function(scope, value, callback) {
   var request = Request.buildPublish(scope, value);
-  return this._write(request.getMessage(), callback);
+  return this._write(request, callback);
 };
 
 Client.prototype.subscribe = function(scope, options, callback) {
   callback = callbackSet(callback, options);
   var request = Request.buildSubscribe(scope, options);
-  return this._write(request.getMessage(), callback);
+  return this._write(request, callback);
 };
 
 Client.prototype.unsubscribe = function(scope, callback) {
   var request = Request.buildUnsubscribe(scope);
-  return this._write(request.getMessage(), callback);
+  return this._write(request, callback);
 };
 
 var callbackSet = function (callback, options) {
@@ -181,12 +181,10 @@ var callbackSet = function (callback, options) {
 
 // sync returns the actual value of the operation
 Client.prototype.sync = function (scope, options, callback) {
-  var request = Request.buildSync(scope, options),
-      response;
+  var request = Request.buildSync(scope, options);
 
-  var whenCallback = function (data) {
-    response = Response.parse(data, request.getMessage());
-    if (response) {
+  var whenCallback = function (response) {
+    if (response && response.getAttr('to') === request.getAttr('to')) {
       if (request.getVersion() === 1 && request.isPresence()) {
         response.forceV2Presence();
       }
@@ -202,17 +200,15 @@ Client.prototype.sync = function (scope, options, callback) {
   this.when('get', whenCallback);
 
   // sync does not return ACK (it sends back a data message)
-  return this._write(request.getMessage());
+  return this._write(request);
 };
 
 // get returns the actual value of the operation
 Client.prototype.get = function (scope, options, callback) {
-  var request = Request.buildGet(scope, options),
-      response;
+  var request = Request.buildGet(scope, options);
 
-  var whenCallback = function (data) {
-    response = Response.parse(data, request.getMessage());
-    if (response) {
+  var whenCallback = function (response) {
+    if (response && response.getAttr('to') === request.getAttr('to')) {
       if (callback) {
         callback(response.getMessage());
       }
@@ -225,7 +221,7 @@ Client.prototype.get = function (scope, options, callback) {
   this.when('get', whenCallback);
 
   // get does not return ACK (it sends back a data message)
-  return this._write(request.getMessage());
+  return this._write(request);
 };
 
 // Private API
@@ -235,43 +231,43 @@ var _buildScopeName = function (type, configuration, scope) {
 };
 
 Client.prototype._addListeners = function () {
-  // Add authentication data to a message; _write() emits authenticateMessage
-  this.on('authenticateMessage', function(message) {
-    Request.setUserData(message, this._configuration);
-    Request.setAuthData(message, this._configuration);
+  // Add authentication data to a request message; _write() emits authenticateMessage
+  this.on('authenticateMessage', function(request) {
+    request.setAttr('userData', this._configuration);
+    request.setAuthData(this._configuration);
 
-    this.emit('messageAuthenticated', message);
+    this.emit('messageAuthenticated', request);
   });
 
-  // Once the message is authenticated, send it to the server
-  this.on('messageAuthenticated', function(message) {
-    this._sendMessage(message);
+  // Once the request is authenticated, send it to the server
+  this.on('messageAuthenticated', function(request) {
+    this._sendMessage(request);
   });
 };
 
-Client.prototype._write = function(message, callback) {
+Client.prototype._write = function(request, callback) {
   var self = this;
 
   if (callback) {
-    Request.setAttr(message, 'ack', this._ackCounter++);
+    request.setAttr('ack', this._ackCounter++);
 
     // Wait ack
-    this.when('ack', function(data) {
-      self.logger().debug('ack', data);
-      if (!Response.parse(data, message)) { return false; }
-      callback(message);
+    this.when('ack', function(response) {
+      self.logger().debug('ack', response);
+      if (response.getAttr('value') != request.getAttr('ack')) { return false; }
+      callback(request.getMessage());
 
       return true;
     });
   }
-  this.emit('authenticateMessage', message);
+  this.emit('authenticateMessage', request);
   return this;
 };
 
-Client.prototype._batch = function(message) {
-  var to = Response.getAttr(message, 'to'),
-      value = Response.getAttr(message, 'value'),
-      time = Response.getAttr(message, 'time');
+Client.prototype._batch = function(response) {
+  var to = response.getAttr('to'),
+      value = response.getAttr('value'),
+      time = response.getAttr('time');
 
   if (!to || !value || !time) {
     return false;
@@ -361,10 +357,10 @@ Client.prototype._createManager = function() {
 
 // Memorize subscriptions and presence states; return "true" for a message that
 // adds to the memorized subscriptions or presences
-Client.prototype._memorize = function(message) {
-  var op = Request.getAttr(message, 'op'),
-      to = Request.getAttr(message, 'to'),
-      value = Request.getAttr(message, 'value');
+Client.prototype._memorize = function(request) {
+  var op = request.getAttr('op'),
+      to = request.getAttr('to'),
+      value = request.getAttr('value');
 
   switch(op) {
     case 'unsubscribe':
@@ -392,10 +388,9 @@ Client.prototype._memorize = function(message) {
 };
 
 Client.prototype._restore = function() {
-  var item, i, to, message, counts = { subscriptions: 0, presences: 0, messages: 0 };
+  var item, to, counts = { subscriptions: 0, presences: 0, messages: 0 };
   if (this._restoreRequired) {
     this._restoreRequired = false;
-
 
     for (to in this._subscriptions) {
       if (this._subscriptions.hasOwnProperty(to)) {
@@ -421,18 +416,18 @@ Client.prototype._restore = function() {
   }
 };
 
-Client.prototype._sendMessage = function(message) {
-  var memorized = this._memorize(message),
-      ack = Request.getAttr(message, 'ack');
+Client.prototype._sendMessage = function(request) {
+  var memorized = this._memorize(request),
+      ack = request.getAttr('ack');
 
-  this.emit('message:out', message);
+  this.emit('message:out', request.getMessage());
 
   if (this._socket && this.manager.is('activated')) {
-    this._socket.sendPacket('message', JSON.stringify(message));
+    this._socket.sendPacket('message', JSON.stringify(request.getMessage()));
   } else if (this._isConfigured) {
     this._restoreRequired = true;
     if (!memorized || ack) {
-      this._queuedMessages.push(message);
+      this._queuedMessages.push(request);
     }
     this.manager.connectWhenAble();
   }
@@ -449,11 +444,11 @@ Client.prototype._messageReceived = function (msg) {
     case 'err':
     case 'ack':
     case 'get':
-      this.emitNext(op, message);
+      this.emitNext(op, new Response(message));
       break;
 
     case 'sync':
-      this._batch(message);
+      this._batch(new Response(message)); 
       break;
 
     default:

--- a/lib/radar_client.js
+++ b/lib/radar_client.js
@@ -5,7 +5,9 @@ var MicroEE = require('microee'),
     StateMachine = require('./state.js'),
     immediate = typeof setImmediate != 'undefined' ? setImmediate :
                                     function(fn) { setTimeout(fn, 1); },
-    getClientVersion = require('./client_version.js');
+    getClientVersion = require('./client_version.js'),
+    Request = require('./message_request.js'),
+    Response = require('./message_response.js');
 
 function Client(backend) {
   var self = this;
@@ -112,160 +114,135 @@ Client.prototype.currentClientId = function() {
   return this._socket && this._socket.id;
 };
 
+// Return the scope object for a given message type
+
 Client.prototype.message = function(scope) {
-  return new Scope('message:/'+this._configuration.accountName+'/'+scope, this);
+  return new Scope(_buildScopeName('message', this._configuration, scope), this);
 };
 
 // Access the "presence" chainable operations
 Client.prototype.presence = function(scope) {
-  return new Scope('presence:/'+this._configuration.accountName+'/'+scope, this);
+  return new Scope(_buildScopeName('presence', this._configuration, scope), this);
 };
 
 // Access the "status" chainable operations
 Client.prototype.status = function(scope) {
-  return new Scope('status:/'+this._configuration.accountName+'/'+scope, this);
+  return new Scope(_buildScopeName('status', this._configuration, scope), this);
 };
 
 Client.prototype.stream = function(scope) {
-  return new Scope('stream:/'+this._configuration.accountName+'/'+scope, this);
+  return new Scope(_buildScopeName('stream', this._configuration, scope), this);
 };
 
 // Access the "control" chainable operations
 Client.prototype.control = function(scope) {
-  return new Scope('control:/'+this._configuration.accountName+'/'+scope, this);
+  return new Scope(_buildScopeName('control', this._configuration, scope), this);
 };
 
+// Operations
+
 Client.prototype.nameSync = function(scope, options, callback) {
-  var message = { op: 'nameSync', to: scope };
-  if (typeof options == 'function') {
-    callback = options;
-  } else {
-    message.options = options;
-  }
-  return this._write(message, callback);
+  return this._write(Request.buildNameSync(scope, options).getMessage(), callback);
 };
 
 Client.prototype.push = function(scope, resource, action, value, callback) {
-  return this._write({
-    op: 'push',
-    to: scope,
-    resource: resource,
-    action: action,
-    value: value
-  }, callback);
+  return this._write(Request.buildPush(scope, resource, action, value).getMessage(), callback);
 };
 
 Client.prototype.set = function(scope, value, clientData, callback) {
-  var message = {
-    op: 'set',
-    to: scope,
-    value: value,
-    key: this._configuration.userId,
-    type: this._configuration.userType
-  };
-
-  if (typeof(clientData) === 'function') {
-    callback = clientData;
-  } else {
-    message.clientData = clientData;
-  }
-
-  return this._write(message, callback);
+  callback = callbackSet(callback, clientData);
+  return this._write(Request.buildSet(scope, value, clientData,
+          this._configuration.userId, this._configuration.userType).getMessage(), callback);
 };
 
 Client.prototype.publish = function(scope, value, callback) {
-  return this._write({
-    op: 'publish',
-    to: scope,
-    value: value
-  }, callback);
+  return this._write(Request.buildPublish(scope, value).getMessage(), callback);
 };
 
 Client.prototype.subscribe = function(scope, options, callback) {
-  var message = { op: 'subscribe', to: scope };
-  if (typeof options == 'function') {
-    callback = options;
-  } else {
-    message.options = options;
-  }
-  return this._write(message, callback);
+  callback = callbackSet(callback, options);
+  return this._write(Request.buildSubscribe(scope, options).getMessage(), callback);
 };
 
 Client.prototype.unsubscribe = function(scope, callback) {
-  return this._write({ op: 'unsubscribe', to: scope }, callback);
+  return this._write(Request.buildUnsubscribe(scope).getMessage(), callback);
 };
 
-// Sync and get return the actual value of the operation
-var init = function(propertyName) {
-  Client.prototype[propertyName] = function(scope, options, callback) {
-    var message = { op: propertyName, to: scope };
-    // options is an optional argument
-    if (typeof options == 'function') {
-      callback = options;
-    } else {
-      message.options = options;
-    }
-    // Sync v1 for presence scopes acts inconsistently. The result should be a
-    // "get" message, but it is actually a "online" message.
-    // So force v2 and translate the result to v1 format.
-    if (propertyName == 'sync' && !message.options && scope.match(/^presence.+/)) {
-      message.options = { version: 2 };
-      this.when('get', function(message) {
-        var value = {}, userId;
-        if (!message || !message.to || message.to != scope) {
-          return false;
-        }
-
-        for (userId in message.value) {
-          if (message.value.hasOwnProperty(userId)) {
-            // Skip when not defined; causes exception in FF for 'Work Offline'
-            if (!message.value[userId]) { continue; }
-            value[userId] = message.value[userId].userType;
-          }
-        }
-        message.value = value;
-        message.op = 'online';
-        if (callback) {
-          callback(message);
-        }
-        return true;
-      });
-    } else {
-      this.when('get', function(message) {
-        if (!message || !message.to || message.to != scope) {
-          return false;
-        }
-        if (callback) {
-          callback(message);
-        }
-        return true;
-      });
-    }
-    // sync/get never register or return acks (since they always send back a
-    // data message)
-    return this._write(message);
-  };
+var callbackSet = function (callback, options) {
+  if (typeof options === 'function') { callback = options; }
+  return callback;
 };
 
-var props = ['get', 'sync'];
-for(var i = 0; i < props.length; i++){
-  init(props[i]);
-}
+// sync returns the actual value of the operation
+Client.prototype.sync = function (scope, options, callback) {
+  var request = Request.buildSync(scope, options),
+      response;
+
+  callback = callbackSet(callback, options);
+  if (!request.isOptionsSet() && request.isPresence()) {
+    request.setOptionsVersion(2);
+    this.when('get', function (data) {
+      response = Response.parse(data, request.getMessage());
+      if (response) {
+        // force v2 presence
+        response.forceV2Presence();
+        if (callback) {
+          callback(response.getMessage());
+        }
+        return true;
+      }
+      return false;
+    });
+  } else {
+    this.when('get', function (data) {
+      response = Response.parse(data, request.getMessage());
+      if (response) {
+        if (callback) {
+          callback(response.getMessage());
+        }
+        return true;
+      }
+      return false;
+    });
+  }
+
+  // sync does not return ACK (it sends back a data message)
+  return this._write(request.getMessage());
+};
+
+// get returns the actual value of the operation
+Client.prototype.get = function (scope, options, callback) {
+  var request = Request.buildGet(scope, options),
+      response;
+
+  callback = callbackSet(callback, options);
+  this.when('get', function (data) {
+    response = Response.parse(data, request.getMessage());
+    if (response) {
+      if (callback) {
+        callback(response.getMessage());
+      }
+      return true;
+    }
+    return false;
+  });
+
+  // get does not return ACK (it sends back a data message)
+  return this._write(request.getMessage());
+};
 
 // Private API
+
+var _buildScopeName = function (type, configuration, scope) {
+  return type + ':/' + configuration.accountName + '/' + scope;
+};
 
 Client.prototype._addListeners = function () {
   // Add authentication data to a message; _write() emits authenticateMessage
   this.on('authenticateMessage', function(message) {
-    if (this._configuration) {
-      message.userData = this._configuration.userData;
-      if (this._configuration.auth) {
-        message.auth = this._configuration.auth;
-        message.userId = this._configuration.userId;
-        message.userType = this._configuration.userType;
-        message.accountName = this._configuration.accountName;
-      }
-    }
+    Request.setUserData(message, this._configuration);
+    Request.setAuthData(message, this._configuration);
+
     this.emit('messageAuthenticated', message);
   });
 
@@ -276,17 +253,17 @@ Client.prototype._addListeners = function () {
 };
 
 Client.prototype._write = function(message, callback) {
-  var client = this;
+  var self = this;
 
   if (callback) {
-    message.ack = this._ackCounter++;
+    Request.setAck(message, this._ackCounter++);
+
     // Wait ack
-    this.when('ack', function(m) {
-      client.logger().debug('ack', m);
-      if (!m || !m.value || m.value != message.ack) {
-        return false;
-      }
+    this.when('ack', function(data) {
+      self.logger().debug('ack', data);
+      if (!Response.parse(data, message)) { return false; }
       callback(message);
+
       return true;
     });
   }
@@ -294,53 +271,78 @@ Client.prototype._write = function(message, callback) {
   return this;
 };
 
+/*
+Client.prototype._write_new = function(request, callback) {
+  var self = this;
+
+  if (callback) {
+    request.setAck(this._ackCounter++);
+
+    // Wait ack
+    this.when('ack', function(data) {
+      self.logger().debug('ack', data);
+      if (!Response.parse(data, request)) { return false; }
+      callback(request.getMessage());
+
+      return true;
+    });
+  }
+  this.emit('authenticateMessage', request);
+  return this;
+};
+*/
+
 Client.prototype._batch = function(message) {
-  if (!(message.to && message.value && message.time)) {
+  var to = Request.getTo(message),
+      value = Request.getValue(message),
+      time = Request.getTime(message);
+
+  if (!to || !value || !time) {
     return false;
   }
 
-  var index = 0, data, time,
-      length = message.value.length,
-      newest = message.time,
-      current = this._channelSyncTimes[message.to] || 0;
+  var index = 0, data,
+      length = value.length,
+      newest = time,
+      current = this._channelSyncTimes[to] || 0;
 
   for (; index < length; index = index + 2) {
-    data = JSON.parse(message.value[index]);
-    time = message.value[index + 1];
+    data = JSON.parse(value[index]);
+    time = value[index + 1];
 
     if (time > current) {
-      this.emitNext(message.to, data);
+      this.emitNext(to, data);
     }
     if (time > newest) {
       newest = time;
     }
   }
-  this._channelSyncTimes[message.to] = newest;
+  this._channelSyncTimes[to] = newest;
 };
 
 Client.prototype._createManager = function() {
-  var client = this, manager = this.manager = StateMachine.create();
+  var self = this, manager = this.manager = StateMachine.create();
 
   manager.on('enterState', function(state) {
-    client.emit(state);
+    self.emit(state);
   });
 
   manager.on('event', function(event) {
-    client.emit(event);
+    self.emit(event);
   });
 
   manager.on('connect', function(data) {
-    var socket = client._socket = new client.backend.Socket(client._configuration);
+    var socket = self._socket = new self.backend.Socket(self._configuration);
 
     socket.once('open', function() {
-      client.logger().debug("socket open", socket.id);
+      self.logger().debug("socket open", socket.id);
       manager.established();
     });
 
     socket.once('close', function(reason, description) {
-      client.logger().debug('socket closed', socket.id, reason, description);
+      self.logger().debug('socket closed', socket.id, reason, description);
       socket.removeAllListeners('message');
-      client._socket = null;
+      self._socket = null;
 
       // Patch for polling-xhr continuing to poll after socket close (HTTP:POST
       // failure).  socket.transport is in error but not closed, so if a subsequent
@@ -355,8 +357,8 @@ Client.prototype._createManager = function() {
       }
     });
 
-    socket.on('message', function(message) {
-      client._messageReceived(message);
+    socket.on('message', function (message) {
+      self._messageReceived(message);
     });
 
     manager.removeAllListeners('close');
@@ -366,9 +368,9 @@ Client.prototype._createManager = function() {
   });
 
   manager.on('activate', function() {
-    client._identitySet();
-    client._restore();
-    client.emit('ready');
+    self._identitySet();
+    self._restore();
+    self.emit('ready');
   });
 
   manager.on('authenticate', function() {
@@ -377,32 +379,39 @@ Client.prototype._createManager = function() {
   });
 
   manager.on('disconnect', function() {
-    client._restoreRequired = true;
+    self._restoreRequired = true;
   });
 };
 
 // Memorize subscriptions and presence states; return "true" for a message that
 // adds to the memorized subscriptions or presences
 Client.prototype._memorize = function(message) {
-  switch(message.op) {
+  var op = Request.getOp(message),
+      to = Request.getTo(message),
+      value = Request.getValue(message);
+
+  switch(op) {
     case 'unsubscribe':
       // Remove from queue
-      if (this._subscriptions[message.to]) {
-        delete this._subscriptions[message.to];
+      if (this._subscriptions[to]) {
+        delete this._subscriptions[to];
       }
       return true;
+
     case 'sync':
     case 'subscribe':
-      if (this._subscriptions[message.to] != 'sync') {
-        this._subscriptions[message.to] = message.op;
+      if (this._subscriptions[to] != 'sync') {
+        this._subscriptions[to] = op;
       }
       return true;
+
     case 'set':
-      if (message.to.substr(0, 'presence:/'.length) == 'presence:/') {
-        this._presences[message.to] = message.value;
+      if (to.substr(0, 'presence:/'.length) == 'presence:/') {
+        this._presences[to] = value;
         return true;
       }
   }
+
   return false;
 };
 
@@ -437,14 +446,16 @@ Client.prototype._restore = function() {
 };
 
 Client.prototype._sendMessage = function(message) {
-  var memorized = this._memorize(message);
+  var memorized = this._memorize(message),
+      ack = Request.getAck(message);
+
   this.emit('message:out', message);
 
   if (this._socket && this.manager.is('activated')) {
     this._socket.sendPacket('message', JSON.stringify(message));
   } else if (this._isConfigured) {
     this._restoreRequired = true;
-    if (!memorized || message.ack) {
+    if (!memorized || ack) {
       this._queuedMessages.push(message);
     }
     this.manager.connectWhenAble();
@@ -452,25 +463,31 @@ Client.prototype._sendMessage = function(message) {
 };
 
 Client.prototype._messageReceived = function (msg) {
-  var message = JSON.parse(msg);
+  var message = JSON.parse(msg),
+      op = Request.getOp(message),
+      to = Request.getTo(message);
+
   this.emit('message:in', message);
-  switch (message.op) {
+
+  switch (op) {
     case 'err':
     case 'ack':
     case 'get':
-      this.emitNext(message.op, message);
+      this.emitNext(op, message);
       break;
+
     case 'sync':
       this._batch(message);
       break;
+
     default:
-      this.emitNext(message.to, message);
+      this.emitNext(to, message);
   }
 };
 
 Client.prototype.emitNext = function() {
-  var args = Array.prototype.slice.call(arguments), client = this;
-  immediate(function(){ client.emit.apply(client, args); });
+  var args = Array.prototype.slice.call(arguments), self = this;
+  immediate(function(){ self.emit.apply(self, args); });
 };
 
 Client.prototype._identitySet = function () {

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -6,7 +6,7 @@ function Scope(prefix, client) {
 var props = [ 'set', 'get', 'subscribe', 'unsubscribe', 'publish', 'push', 'sync',
   'on', 'once', 'when', 'removeListener', 'removeAllListeners', 'nameSync'];
 
-var init = function(name) {
+var init = function (name) {
   Scope.prototype[name] = function () {
     var args = Array.prototype.slice.apply(arguments);
     args.unshift(this.prefix);
@@ -15,7 +15,7 @@ var init = function(name) {
   };
 };
 
-for(var i = 0; i < props.length; i++){
+for (var i = 0; i < props.length; i++){
   init(props[i]);
 }
 

--- a/tests/radar_client.unit.test.js
+++ b/tests/radar_client.unit.test.js
@@ -2,6 +2,7 @@ var assert = require('assert'),
     RadarClient = require('../lib/radar_client.js'),
     MockEngine = require('./lib/engine.js'),
     Request = require('../lib/message_request.js'),
+    Response = require('../lib/message_response.js'),
     HOUR = 1000 * 60 * 60,
     client;
 
@@ -215,9 +216,11 @@ exports.RadarClient = {
       client.configure({ accountName: 'test', userId: 123, userType: 0 });
       assert.ok(!client.manager.is('activated'));
       client.subscribe('status:/test/account/1', function(){});
+      //console.log('test: got here 1');
       assert.ok(client._restoreRequired);
       assert.ok(!client.manager.is('activated'));
       assert.equal(client._queuedMessages.length, 1);
+      //console.log('test: got here 2');
       assert.deepEqual(client._subscriptions, { 'status:/test/account/1': 'subscribe' });
     },
 
@@ -304,6 +307,7 @@ exports.RadarClient = {
           passed = false,
           scope = 'status:/test/account/1',
           message = { op: 'get', to: scope },
+          //response = new Response(JSON.stringify(message)),
           callback = function(msg) {
             passed = true;
             assert.deepEqual(msg, message);
@@ -311,6 +315,7 @@ exports.RadarClient = {
 
       client.when = function(operation, fn) {
         called = true;
+        //fn(response);
         fn(message);
       };
 
@@ -323,12 +328,15 @@ exports.RadarClient = {
       var called = false,
           passed = true,
           message = { op: 'get', to: 'status:/test/account/2' },
+          //response = new Response(JSON.stringify(message)),
           callback = function(msg) {
+            console.log('test: callback CALLED.....');
             passed = false;
           };
 
       client.when = function(operation, fn) {
         called = true;
+        //fn(response);
         fn(message);
       };
 
@@ -336,6 +344,9 @@ exports.RadarClient = {
         { client.get('status:/test/account/1', callback); },
         /Invalid response/
       );
+      //client.get('status:/test/account/1', callback);
+      console.log('test: called:', called);
+      console.log('test: passed:', passed);
       assert.ok(called);
       assert.ok(passed);
     }
@@ -375,6 +386,7 @@ exports.RadarClient = {
             passed = false,
             scope = 'presence:/test/account/1',
             message = { op: 'sync', to: scope },
+            //response = new Response(JSON.stringify(message)),
             callback = function(msg) {
               passed = true;
               assert.deepEqual(msg, message);
@@ -382,6 +394,7 @@ exports.RadarClient = {
 
         client.when = function(operation, fn) {
           called = true;
+          //fn(response);
           fn(message);
         };
 
@@ -394,12 +407,14 @@ exports.RadarClient = {
         var called = false,
             passed = true,
             message = { op: 'sync', to: 'presence:/test/account/2' },
+            //response = new Response(JSON.stringify(message)),
             callback = function(msg) {
               passed = false;
             };
 
         client.when = function(operation, fn) {
           called = true;
+          //fn(response);
           fn(message);
         };
 
@@ -407,6 +422,7 @@ exports.RadarClient = {
           { client.sync('presence:/test/account/1', { version: 2 }, callback); },
           /Invalid response/
         );
+        //client.sync('presence:/test/account/1', { version: 2 }, callback);
         assert.ok(called);
         assert.ok(passed);
       }

--- a/tests/radar_client.unit.test.js
+++ b/tests/radar_client.unit.test.js
@@ -216,11 +216,9 @@ exports.RadarClient = {
       client.configure({ accountName: 'test', userId: 123, userType: 0 });
       assert.ok(!client.manager.is('activated'));
       client.subscribe('status:/test/account/1', function(){});
-      //console.log('test: got here 1');
       assert.ok(client._restoreRequired);
       assert.ok(!client.manager.is('activated'));
       assert.equal(client._queuedMessages.length, 1);
-      //console.log('test: got here 2');
       assert.deepEqual(client._subscriptions, { 'status:/test/account/1': 'subscribe' });
     },
 
@@ -307,7 +305,6 @@ exports.RadarClient = {
           passed = false,
           scope = 'status:/test/account/1',
           message = { op: 'get', to: scope },
-          //response = new Response(JSON.stringify(message)),
           callback = function(msg) {
             passed = true;
             assert.deepEqual(msg, message);
@@ -315,7 +312,6 @@ exports.RadarClient = {
 
       client.when = function(operation, fn) {
         called = true;
-        //fn(response);
         fn(message);
       };
 
@@ -328,15 +324,12 @@ exports.RadarClient = {
       var called = false,
           passed = true,
           message = { op: 'get', to: 'status:/test/account/2' },
-          //response = new Response(JSON.stringify(message)),
           callback = function(msg) {
-            console.log('test: callback CALLED.....');
             passed = false;
           };
 
       client.when = function(operation, fn) {
         called = true;
-        //fn(response);
         fn(message);
       };
 
@@ -344,9 +337,6 @@ exports.RadarClient = {
         { client.get('status:/test/account/1', callback); },
         /Invalid response/
       );
-      //client.get('status:/test/account/1', callback);
-      console.log('test: called:', called);
-      console.log('test: passed:', passed);
       assert.ok(called);
       assert.ok(passed);
     }
@@ -386,7 +376,6 @@ exports.RadarClient = {
             passed = false,
             scope = 'presence:/test/account/1',
             message = { op: 'sync', to: scope },
-            //response = new Response(JSON.stringify(message)),
             callback = function(msg) {
               passed = true;
               assert.deepEqual(msg, message);
@@ -394,7 +383,6 @@ exports.RadarClient = {
 
         client.when = function(operation, fn) {
           called = true;
-          //fn(response);
           fn(message);
         };
 
@@ -407,14 +395,12 @@ exports.RadarClient = {
         var called = false,
             passed = true,
             message = { op: 'sync', to: 'presence:/test/account/2' },
-            //response = new Response(JSON.stringify(message)),
             callback = function(msg) {
               passed = false;
             };
 
         client.when = function(operation, fn) {
           called = true;
-          //fn(response);
           fn(message);
         };
 
@@ -422,7 +408,6 @@ exports.RadarClient = {
           { client.sync('presence:/test/account/1', { version: 2 }, callback); },
           /Invalid response/
         );
-        //client.sync('presence:/test/account/1', { version: 2 }, callback);
         assert.ok(called);
         assert.ok(passed);
       }


### PR DESCRIPTION
Second version of the message library, used by radar_client. Refactor lib/radar_client.js to write separate, explicit get and sync functions. Identify request (aka client) and response (aka server) messages, and associated message lib API calls (now with some  server response messages.)

The first implementation is in the now closed PR https://github.com/zendesk/radar_client/pull/51.  This new implementation differs in the sense that the code is more object-oriented, and less factory class based.  The implementation is *not completely* OO since some of the existing tests are tightly bound to internal method implementations (and associated mocks.)  Some tests have been modified, but the majority have not.

Tomorrow I will review this new implementation to see whether or not it's cost-effective to remove the remaining raw message manipulation in favor of resource/response object handling, as such changes will require additional refactoring of existing tests and other internal methods.

/cc @zendesk/zendesk-radar

### Steps to merge
 - [ ] :+1: of the team

### References
 - Jira link:  https://zendesk.atlassian.net/browse/RADAR-481

### Risks
 - Medium to High: all existing client messages are now provided by the library, so a lot of logic has changed.