### PR TITLE
Copy code changes from PR 52 to this branch off the feature branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,5 +6,5 @@ notifications:
   flowdock:
     secure: GzhfVfSDKQtvfCaHHh2AYTLn/kWOUvHK+SM44AfWX10pwQXCicSR5kx7jMIDrU//0+T2CP/m1EJDnK15CTix+vRJLTwybgc4b8NOl0XmnZXVcW+4i8uhKnXA3bm6+dgVxvUCwNy69dbk7H7CkyFZOzJcZCVliiRBZcbj41uwMqc=
 branches:
-  only: [master, staging, production, pobrien/feature_message_protocol_v2_branch1]
+  only: [master, staging, production]
 sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,4 @@ notifications:
   flowdock:
     secure: GzhfVfSDKQtvfCaHHh2AYTLn/kWOUvHK+SM44AfWX10pwQXCicSR5kx7jMIDrU//0+T2CP/m1EJDnK15CTix+vRJLTwybgc4b8NOl0XmnZXVcW+4i8uhKnXA3bm6+dgVxvUCwNy69dbk7H7CkyFZOzJcZCVliiRBZcbj41uwMqc=
 branches:
-  only: [master, staging, production, pobrien/server_side_client_state]
+  only: [master, staging, production, pobrien/feature_message_protocol_v2]

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,5 +6,5 @@ notifications:
   flowdock:
     secure: GzhfVfSDKQtvfCaHHh2AYTLn/kWOUvHK+SM44AfWX10pwQXCicSR5kx7jMIDrU//0+T2CP/m1EJDnK15CTix+vRJLTwybgc4b8NOl0XmnZXVcW+4i8uhKnXA3bm6+dgVxvUCwNy69dbk7H7CkyFZOzJcZCVliiRBZcbj41uwMqc=
 branches:
-  only: [master, staging, production]
+  only: [master, staging, production, pobrien/feature_message_protocol_v2_branch1]
 sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,4 @@ notifications:
   flowdock:
     secure: GzhfVfSDKQtvfCaHHh2AYTLn/kWOUvHK+SM44AfWX10pwQXCicSR5kx7jMIDrU//0+T2CP/m1EJDnK15CTix+vRJLTwybgc4b8NOl0XmnZXVcW+4i8uhKnXA3bm6+dgVxvUCwNy69dbk7H7CkyFZOzJcZCVliiRBZcbj41uwMqc=
 branches:
-  only: [master, staging, production, pobrien/feature_message_protocol_v2]
+  only: [master, staging, production]

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 node_js:
   - "0.10"
-script: npm test && ./scripts/run_radar_tests
+script: npm test
 notifications:
   flowdock:
     secure: GzhfVfSDKQtvfCaHHh2AYTLn/kWOUvHK+SM44AfWX10pwQXCicSR5kx7jMIDrU//0+T2CP/m1EJDnK15CTix+vRJLTwybgc4b8NOl0XmnZXVcW+4i8uhKnXA3bm6+dgVxvUCwNy69dbk7H7CkyFZOzJcZCVliiRBZcbj41uwMqc=

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
 language: node_js
 node_js:
   - "0.10"
-script: npm test
+script: npm test && ./scripts/run_radar_tests
 notifications:
   flowdock:
     secure: GzhfVfSDKQtvfCaHHh2AYTLn/kWOUvHK+SM44AfWX10pwQXCicSR5kx7jMIDrU//0+T2CP/m1EJDnK15CTix+vRJLTwybgc4b8NOl0XmnZXVcW+4i8uhKnXA3bm6+dgVxvUCwNy69dbk7H7CkyFZOzJcZCVliiRBZcbj41uwMqc=
 branches:
-  only: [master, staging, production]
+  only: [master, staging, production, pobrien/feature_message_protocol_v2_branch1]
 sudo: false

--- a/dist/radar_client.js
+++ b/dist/radar_client.js
@@ -89,10 +89,10 @@ Request.buildNameSync = function (scope, options) {
 Request.buildSet = function (scope, value, clientData, key, userType) {
   var request = new Request('set', scope);
   request.setAttr('value', value);
-  request._setAttrOptionalDefined('key', key);
-  request._setAttrOptionalUndefined('type', userType);
+  request.setAttrOptionalDefined('key', key);
+  request.setAttrOptionalUndefined('type', userType);
   if (typeof(clientData) != 'function') {
-    request._setAttrOptionalUndefined('clientData', clientData);
+    request.setAttrOptionalUndefined('clientData', clientData);
   }
   return request;
 };
@@ -137,12 +137,6 @@ Request.getAttr = function (message, attr) {
   return (message && message[attr]);
 };
 
-/*
-Request.setAttr = function (message, attr, value) {
-  if (message && attr) { message[attr] = value; }
-};
-*/
-
 // Instance methods
 
 Request.prototype.getMessage = function () {
@@ -164,13 +158,13 @@ Request.prototype.isPresence = function () {
   return this.type === 'presence';
 };
 
-Request.prototype._setAttrOptionalUndefined = function (keyName, keyValue) {
+Request.prototype.setAttrOptionalUndefined = function (keyName, keyValue) {
   if (keyName) {
     this.message[keyName] = keyValue;
   }
 };
 
-Request.prototype._setAttrOptionalDefined = function (keyName, keyValue) {
+Request.prototype.setAttrOptionalDefined = function (keyName, keyValue) {
   if (keyName && keyValue) {
     this.message[keyName] = keyValue;
   }

--- a/dist/radar_client.js
+++ b/dist/radar_client.js
@@ -109,27 +109,13 @@ Request.buildUnsubscribe = function (scope, options) {
   return new Request('unsubscribe', scope);
 };
 
+// TO DO: config class should return the required data via getters
 Request.prototype.setAuthData = function (configuration) {
   if (configuration && configuration.auth) {
     this.setAttr('auth', configuration.auth);
     this.setAttr('userId', configuration.userId);
     this.setAttr('userType', configuration.userType);
     this.setAttr('accountName', configuration.accountName);
-  }
-};
-
-// TO DO: config class should return the required data via getters
-Request.setUserData_old = function (message, configuration) {
-  message.userData = configuration && configuration.userData;
-};
-
-// TO DO: config class should return the required data via getters
-Request.setAuthData_old = function (message, configuration) {
-  if (configuration && configuration.auth) {
-    message.auth = configuration.auth;
-    message.userId = configuration.userId;
-    message.userType = configuration.userType;
-    message.accountName = configuration.accountName;
   }
 };
 
@@ -176,13 +162,6 @@ Request.prototype.setAttrOptional = function (keyName, keyValue) {
   if (keyName && (keyValue === 0 || keyValue)) {
     this.message[keyName] = keyValue;
   }
-};
-
-Request.prototype.setAttr_old = function (keyName, keyValue) {
-  if (!keyName || !keyValue) {
-    throw new Error('Invalid request attribute');
-  }
-  this.message[keyName] = keyValue;
 };
 
 Request.prototype.getAttr = function (keyName) {

--- a/dist/radar_client.js
+++ b/dist/radar_client.js
@@ -42,6 +42,260 @@ instance.Backoff = Backoff;
 
 module.exports = instance;
 },
+"lib/message_request.js": function(module, exports, require){var logger = require('minilog')('message:request');
+
+var opTable = {
+  control: ['nameSync'],
+  message: ['publish', 'subscribe', 'sync', 'unsubscribe'],
+  presence: ['get', 'set', 'subscribe', 'sync', 'unsubscribe'],
+  status: ['get', 'set', 'subscribe', 'sync', 'unsubscribe'],
+  stream: ['get', 'push', 'subscribe', 'sync']
+};
+
+var Request = function (operation, scope) {
+  this.message = {
+    op: operation,
+    to: scope
+  };
+
+  if (!this._isValid()) {
+    throw new Error('Invalid request message.');
+  }
+};
+
+Request.buildGet = function (scope, options) {
+  return new Request('get', scope).setOptions(options);
+};
+
+Request.buildPublish = function (scope, value) {
+  var request = new Request('publish', scope);
+  request.setAttr('value', value);
+  return request;
+};
+
+Request.buildPush = function (scope, resource, action, value) {
+  var request = new Request('push', scope);
+  request.setAttr('resource', resource);
+  request.setAttr('action', action);
+  request.setAttr('value', value);
+
+  return request;
+};
+
+Request.buildNameSync = function (scope, options) {
+  return new Request('nameSync', scope).setOptions(options);
+};
+
+Request.buildSet = function (scope, value, clientData, key, userType) {
+  var request = new Request('set', scope);
+  request.setAttr('value', value);
+  request._setAttrOptionalDefined('key', key);
+  request._setAttrOptionalUndefined('type', userType);
+  if (typeof(clientData) != 'function') {
+    request._setAttrOptionalUndefined('clientData', clientData);
+  }
+  return request;
+};
+
+Request.buildSync = function (scope, options) {
+  return new Request('sync', scope).setOptions(options);
+};
+
+Request.buildSubscribe = function (scope, options) {
+  return new Request('subscribe', scope).setOptions(options);
+};
+
+Request.buildUnsubscribe = function (scope, options) {
+  return new Request('unsubscribe', scope);
+};
+
+Request.prototype.setAuthData = function (configuration) {
+  if (configuration && configuration.auth) {
+    this.setAttr('auth', configuration.auth);
+    this.setAttr('userId', configuration.userId);
+    this.setAttr('userType', configuration.userType);
+    this.setAttr('accountName', configuration.accountName);
+  }
+};
+
+// TO DO: config class should return the required data via getters
+Request.setUserData_old = function (message, configuration) {
+  message.userData = configuration && configuration.userData;
+};
+
+// TO DO: config class should return the required data via getters
+Request.setAuthData_old = function (message, configuration) {
+  if (configuration && configuration.auth) {
+    message.auth = configuration.auth;
+    message.userId = configuration.userId;
+    message.userType = configuration.userType;
+    message.accountName = configuration.accountName;
+  }
+};
+
+Request.getAttr = function (message, attr) {
+  return (message && message[attr]);
+};
+
+/*
+Request.setAttr = function (message, attr, value) {
+  if (message && attr) { message[attr] = value; }
+};
+*/
+
+// Instance methods
+
+Request.prototype.getMessage = function () {
+  return this.message;
+};
+
+Request.prototype.setOptions = function (options) {
+  if (options && typeof options != 'function') {
+    this.message.options = options;
+    this.version = 2;
+  } else {
+    this.version = 1;
+  }
+
+  return this;
+};
+
+Request.prototype.isPresence = function () {
+  return this.type === 'presence';
+};
+
+Request.prototype._setAttrOptionalUndefined = function (keyName, keyValue) {
+  if (keyName) {
+    this.message[keyName] = keyValue;
+  }
+};
+
+Request.prototype._setAttrOptionalDefined = function (keyName, keyValue) {
+  if (keyName && keyValue) {
+    this.message[keyName] = keyValue;
+  }
+};
+
+Request.prototype.setAttr = function (keyName, keyValue) {
+  if (!keyName || !keyValue) {
+    throw new Error('Invalid request attribute');
+  }
+  this.message[keyName] = keyValue;
+};
+
+Request.prototype.getAttr = function (keyName) {
+  if (keyName) {
+    return this.message[keyName];
+  }
+};
+
+Request.prototype.getVersion = function () {
+  return this.version;
+};
+
+// Private methods
+
+Request.prototype._isValid = function () {
+  if (!this.message.op || !this.message.to) {
+    return false;
+  }
+
+  var type = this._getType();
+  if (type) {
+    this.type = type;
+    return this._isValidType(type) && this._isValidOperation(type);
+  }
+  return false;
+};
+
+Request.prototype._isValidType = function () {
+  var types = Object.keys(opTable);
+  for (var i = 0; i < types.length; i++) {
+    if (types[i] === this.type) { return true; }
+  }
+  return false;
+};
+
+Request.prototype._isValidOperation = function () {
+  var ops = opTable[this.type];
+
+  return ops && ops.indexOf(this.message.op) >= 0;
+};
+
+Request.prototype._getType = function () {
+  return this.message.to.substring(0, this.message.to.indexOf(':'));
+};
+
+module.exports = Request;
+},
+"lib/message_response.js": function(module, exports, require){var logger = require('minilog')('message:response');
+
+function Response (message) {
+  if (typeof(message) === 'string') {
+    this.message = JSON.parse(message);
+  } else {
+    this.message = message;
+  }
+  this.validate();
+}
+
+Response.getAttr = function (message, attr) {
+  return message && message[attr];
+};
+
+Response.prototype.getMessage = function () {
+  return this.message;
+};
+
+Response.prototype.validate = function () {
+  if (!this.message.op) {
+    _throwError('missing op');
+  }
+
+  switch(this.message.op) {
+    case 'ack':
+      if (!this.message.value) { _throwError('missing value'); }
+      break;
+
+    default:
+      if (this.message.op != 'err' && !this.message.to) { _throwError('missing to'); }
+  }
+};
+
+Response.prototype.isValid = function (request) {
+  if (this.getAttr('op') === 'ack') {
+    return this.getAttr('value') === request.getAttr('ack');
+  } else {
+    return this.getAttr('to') === request.getAttr('to');
+  }
+};
+
+Response.prototype.getAttr = function (attr) {
+  return this.message[attr];
+};
+
+Response.prototype.forceV2Presence = function () {
+  // Sync v1 for presence scopes is inconsistent: the result should be a 'get'
+  // message, but instead is an 'online' message.  Take a v2 response and
+  // massage it to v1 format prior to returning to the caller.
+  var message = this.message, value = {}, userId;
+  for (userId in message.value) {
+    if (message.value.hasOwnProperty(userId)) {
+      // Skip when not defined; causes exception in FF for 'Work Offline'
+      if (!message.value[userId]) { continue; }
+      value[userId] = message.value[userId].userType;
+    }
+  }
+  message.value = value;
+  message.op = 'online';
+};
+
+var _throwError = function (errMessage) {
+  throw new Error('response: ' + errMessage);
+};
+
+module.exports = Response;
+},
 "lib/radar_client.js": function(module, exports, require){/* globals setImmediate */
 var MicroEE = require('microee'),
     eio = require('engine.io-client'),
@@ -49,7 +303,9 @@ var MicroEE = require('microee'),
     StateMachine = require('./state.js'),
     immediate = typeof setImmediate != 'undefined' ? setImmediate :
                                     function(fn) { setTimeout(fn, 1); },
-    getClientVersion = require('./client_version.js');
+    getClientVersion = require('./client_version.js'),
+    Request = require('./message_request.js'),
+    Response = require('./message_response.js');
 
 function Client(backend) {
   var self = this;
@@ -156,235 +412,207 @@ Client.prototype.currentClientId = function() {
   return this._socket && this._socket.id;
 };
 
+// Return the scope object for a given message type
+
 Client.prototype.message = function(scope) {
-  return new Scope('message:/'+this._configuration.accountName+'/'+scope, this);
+  return new Scope(_buildScopeName('message', this._configuration, scope), this);
 };
 
 // Access the "presence" chainable operations
 Client.prototype.presence = function(scope) {
-  return new Scope('presence:/'+this._configuration.accountName+'/'+scope, this);
+  return new Scope(_buildScopeName('presence', this._configuration, scope), this);
 };
 
 // Access the "status" chainable operations
 Client.prototype.status = function(scope) {
-  return new Scope('status:/'+this._configuration.accountName+'/'+scope, this);
+  return new Scope(_buildScopeName('status', this._configuration, scope), this);
 };
 
 Client.prototype.stream = function(scope) {
-  return new Scope('stream:/'+this._configuration.accountName+'/'+scope, this);
+  return new Scope(_buildScopeName('stream', this._configuration, scope), this);
 };
 
 // Access the "control" chainable operations
 Client.prototype.control = function(scope) {
-  return new Scope('control:/'+this._configuration.accountName+'/'+scope, this);
+  return new Scope(_buildScopeName('control', this._configuration, scope), this);
 };
 
+// Operations
+
 Client.prototype.nameSync = function(scope, options, callback) {
-  var message = { op: 'nameSync', to: scope };
-  if (typeof options == 'function') {
-    callback = options;
-  } else {
-    message.options = options;
-  }
-  return this._write(message, callback);
+  var request = Request.buildNameSync(scope, options);
+  return this._write(request, callback);
 };
 
 Client.prototype.push = function(scope, resource, action, value, callback) {
-  return this._write({
-    op: 'push',
-    to: scope,
-    resource: resource,
-    action: action,
-    value: value
-  }, callback);
+  var request = Request.buildPush(scope, resource, action, value);
+  return this._write(request, callback);
 };
 
 Client.prototype.set = function(scope, value, clientData, callback) {
-  var message = {
-    op: 'set',
-    to: scope,
-    value: value,
-    key: this._configuration.userId,
-    type: this._configuration.userType
-  };
-
-  if (typeof(clientData) === 'function') {
-    callback = clientData;
-  } else {
-    message.clientData = clientData;
-  }
-
-  return this._write(message, callback);
+  callback = callbackSet(callback, clientData);
+  var request = Request.buildSet(scope, value, clientData,
+                  this._configuration.userId, this._configuration.userType);
+  return this._write(request, callback);
 };
 
 Client.prototype.publish = function(scope, value, callback) {
-  return this._write({
-    op: 'publish',
-    to: scope,
-    value: value
-  }, callback);
+  var request = Request.buildPublish(scope, value);
+  return this._write(request, callback);
 };
 
 Client.prototype.subscribe = function(scope, options, callback) {
-  var message = { op: 'subscribe', to: scope };
-  if (typeof options == 'function') {
-    callback = options;
-  } else {
-    message.options = options;
-  }
-  return this._write(message, callback);
+  callback = callbackSet(callback, options);
+  var request = Request.buildSubscribe(scope, options);
+  return this._write(request, callback);
 };
 
 Client.prototype.unsubscribe = function(scope, callback) {
-  return this._write({ op: 'unsubscribe', to: scope }, callback);
+  var request = Request.buildUnsubscribe(scope);
+  return this._write(request, callback);
 };
 
-// Sync and get return the actual value of the operation
-var init = function(propertyName) {
-  Client.prototype[propertyName] = function(scope, options, callback) {
-    var message = { op: propertyName, to: scope };
-    // options is an optional argument
-    if (typeof options == 'function') {
-      callback = options;
-    } else {
-      message.options = options;
-    }
-    // Sync v1 for presence scopes acts inconsistently. The result should be a
-    // "get" message, but it is actually a "online" message.
-    // So force v2 and translate the result to v1 format.
-    if (propertyName == 'sync' && !message.options && scope.match(/^presence.+/)) {
-      message.options = { version: 2 };
-      this.when('get', function(message) {
-        var value = {}, userId;
-        if (!message || !message.to || message.to != scope) {
-          return false;
-        }
+var callbackSet = function (callback, options) {
+  if (typeof options === 'function') { callback = options; }
+  return callback;
+};
 
-        for (userId in message.value) {
-          if (message.value.hasOwnProperty(userId)) {
-            // Skip when not defined; causes exception in FF for 'Work Offline'
-            if (!message.value[userId]) { continue; }
-            value[userId] = message.value[userId].userType;
-          }
-        }
-        message.value = value;
-        message.op = 'online';
-        if (callback) {
-          callback(message);
-        }
-        return true;
-      });
-    } else {
-      this.when('get', function(message) {
-        if (!message || !message.to || message.to != scope) {
-          return false;
-        }
-        if (callback) {
-          callback(message);
-        }
-        return true;
-      });
+// sync returns the actual value of the operation
+Client.prototype.sync = function (scope, options, callback) {
+  var request = Request.buildSync(scope, options);
+
+  var whenCallback = function (response) {
+    if (response && response.getAttr('to') === request.getAttr('to')) {
+      if (request.getVersion() === 1 && request.isPresence()) {
+        response.forceV2Presence();
+      }
+      if (callback) {
+        callback(response.getMessage());
+      }
+      return true;
     }
-    // sync/get never register or return acks (since they always send back a
-    // data message)
-    return this._write(message);
+    return false;
   };
+
+  callback = callbackSet(callback, options);
+  this.when('get', whenCallback);
+
+  // sync does not return ACK (it sends back a data message)
+  return this._write(request);
 };
 
-var props = ['get', 'sync'];
-for(var i = 0; i < props.length; i++){
-  init(props[i]);
-}
+// get returns the actual value of the operation
+Client.prototype.get = function (scope, options, callback) {
+  var request = Request.buildGet(scope, options);
+
+  var whenCallback = function (response) {
+    if (response && response.getAttr('to') === request.getAttr('to')) {
+      if (callback) {
+        callback(response.getMessage());
+      }
+      return true;
+    }
+    return false;
+  };
+
+  callback = callbackSet(callback, options);
+  this.when('get', whenCallback);
+
+  // get does not return ACK (it sends back a data message)
+  return this._write(request);
+};
 
 // Private API
 
+var _buildScopeName = function (type, configuration, scope) {
+  return type + ':/' + configuration.accountName + '/' + scope;
+};
+
 Client.prototype._addListeners = function () {
-  // Add authentication data to a message; _write() emits authenticateMessage
-  this.on('authenticateMessage', function(message) {
-    if (this._configuration) {
-      message.userData = this._configuration.userData;
-      if (this._configuration.auth) {
-        message.auth = this._configuration.auth;
-        message.userId = this._configuration.userId;
-        message.userType = this._configuration.userType;
-        message.accountName = this._configuration.accountName;
-      }
-    }
-    this.emit('messageAuthenticated', message);
+  // Add authentication data to a request message; _write() emits authenticateMessage
+  this.on('authenticateMessage', function(request) {
+    request.setAttr('userData', this._configuration);
+    request.setAuthData(this._configuration);
+
+    this.emit('messageAuthenticated', request);
   });
 
-  // Once the message is authenticated, send it to the server
-  this.on('messageAuthenticated', function(message) {
-    this._sendMessage(message);
+  // Once the request is authenticated, send it to the server
+  this.on('messageAuthenticated', function(request) {
+    this._sendMessage(request);
   });
 };
 
-Client.prototype._write = function(message, callback) {
-  var client = this;
+Client.prototype._write = function(request, callback) {
+  var self = this;
 
   if (callback) {
-    message.ack = this._ackCounter++;
+    request.setAttr('ack', this._ackCounter++);
+
     // Wait ack
-    this.when('ack', function(m) {
-      client.logger().debug('ack', m);
-      if (!m || !m.value || m.value != message.ack) {
-        return false;
-      }
-      callback(message);
+    this.when('ack', function(response) {
+      self.logger().debug('ack', response);
+      if (response.getAttr('value') != request.getAttr('ack')) { return false; }
+      callback(request.getMessage());
+
       return true;
     });
   }
-  this.emit('authenticateMessage', message);
+  this.emit('authenticateMessage', request);
   return this;
 };
 
-Client.prototype._batch = function(message) {
-  if (!(message.to && message.value && message.time)) {
+Client.prototype._batch = function(response) {
+  var to = response.getAttr('to'),
+      value = response.getAttr('value'),
+      time = response.getAttr('time');
+
+  if (!to || !value || !time) {
     return false;
   }
 
-  var index = 0, data, time,
-      length = message.value.length,
-      newest = message.time,
-      current = this._channelSyncTimes[message.to] || 0;
+  var index = 0, data,
+      length = value.length,
+      newest = time,
+      current = this._channelSyncTimes[to] || 0;
 
   for (; index < length; index = index + 2) {
-    data = JSON.parse(message.value[index]);
-    time = message.value[index + 1];
+    data = JSON.parse(value[index]);
+    time = value[index + 1];
 
     if (time > current) {
-      this.emitNext(message.to, data);
+      this.emitNext(to, data);
     }
     if (time > newest) {
       newest = time;
     }
   }
-  this._channelSyncTimes[message.to] = newest;
+  this._channelSyncTimes[to] = newest;
 };
 
 Client.prototype._createManager = function() {
-  var client = this, manager = this.manager = StateMachine.create();
+  var self = this, manager = this.manager = StateMachine.create();
 
   manager.on('enterState', function(state) {
-    client.emit(state);
+    self.emit(state);
   });
 
   manager.on('event', function(event) {
-    client.emit(event);
+    self.emit(event);
   });
 
   manager.on('connect', function(data) {
-    var socket = client._socket = new client.backend.Socket(client._configuration);
+    var socket = self._socket = new self.backend.Socket(self._configuration);
 
     socket.once('open', function() {
-      client.logger().debug("socket open", socket.id);
+      self.logger().debug("socket open", socket.id);
       manager.established();
     });
 
     socket.once('close', function(reason, description) {
-      client.logger().debug('socket closed', socket.id, reason, description);
+      self.logger().debug('socket closed', socket.id, reason, description);
       socket.removeAllListeners('message');
-      client._socket = null;
+      self._socket = null;
 
       // Patch for polling-xhr continuing to poll after socket close (HTTP:POST
       // failure).  socket.transport is in error but not closed, so if a subsequent
@@ -399,8 +627,8 @@ Client.prototype._createManager = function() {
       }
     });
 
-    socket.on('message', function(message) {
-      client._messageReceived(message);
+    socket.on('message', function (message) {
+      self._messageReceived(message);
     });
 
     manager.removeAllListeners('close');
@@ -410,9 +638,9 @@ Client.prototype._createManager = function() {
   });
 
   manager.on('activate', function() {
-    client._identitySet();
-    client._restore();
-    client.emit('ready');
+    self._identitySet();
+    self._restore();
+    self.emit('ready');
   });
 
   manager.on('authenticate', function() {
@@ -421,40 +649,46 @@ Client.prototype._createManager = function() {
   });
 
   manager.on('disconnect', function() {
-    client._restoreRequired = true;
+    self._restoreRequired = true;
   });
 };
 
 // Memorize subscriptions and presence states; return "true" for a message that
 // adds to the memorized subscriptions or presences
-Client.prototype._memorize = function(message) {
-  switch(message.op) {
+Client.prototype._memorize = function(request) {
+  var op = request.getAttr('op'),
+      to = request.getAttr('to'),
+      value = request.getAttr('value');
+
+  switch(op) {
     case 'unsubscribe':
       // Remove from queue
-      if (this._subscriptions[message.to]) {
-        delete this._subscriptions[message.to];
+      if (this._subscriptions[to]) {
+        delete this._subscriptions[to];
       }
       return true;
+
     case 'sync':
     case 'subscribe':
-      if (this._subscriptions[message.to] != 'sync') {
-        this._subscriptions[message.to] = message.op;
+      if (this._subscriptions[to] != 'sync') {
+        this._subscriptions[to] = op;
       }
       return true;
+
     case 'set':
-      if (message.to.substr(0, 'presence:/'.length) == 'presence:/') {
-        this._presences[message.to] = message.value;
+      if (to.substr(0, 'presence:/'.length) == 'presence:/') {
+        this._presences[to] = value;
         return true;
       }
   }
+
   return false;
 };
 
 Client.prototype._restore = function() {
-  var item, i, to, message, counts = { subscriptions: 0, presences: 0, messages: 0 };
+  var item, to, counts = { subscriptions: 0, presences: 0, messages: 0 };
   if (this._restoreRequired) {
     this._restoreRequired = false;
-
 
     for (to in this._subscriptions) {
       if (this._subscriptions.hasOwnProperty(to)) {
@@ -480,41 +714,49 @@ Client.prototype._restore = function() {
   }
 };
 
-Client.prototype._sendMessage = function(message) {
-  var memorized = this._memorize(message);
-  this.emit('message:out', message);
+Client.prototype._sendMessage = function(request) {
+  var memorized = this._memorize(request),
+      ack = request.getAttr('ack');
+
+  this.emit('message:out', request.getMessage());
 
   if (this._socket && this.manager.is('activated')) {
-    this._socket.sendPacket('message', JSON.stringify(message));
+    this._socket.sendPacket('message', JSON.stringify(request.getMessage()));
   } else if (this._isConfigured) {
     this._restoreRequired = true;
-    if (!memorized || message.ack) {
-      this._queuedMessages.push(message);
+    if (!memorized || ack) {
+      this._queuedMessages.push(request);
     }
     this.manager.connectWhenAble();
   }
 };
 
 Client.prototype._messageReceived = function (msg) {
-  var message = JSON.parse(msg);
+  var message = JSON.parse(msg),
+      op = Response.getAttr(message, 'op'),
+      to = Response.getAttr(message, 'to');
+
   this.emit('message:in', message);
-  switch (message.op) {
+
+  switch (op) {
     case 'err':
     case 'ack':
     case 'get':
-      this.emitNext(message.op, message);
+      this.emitNext(op, new Response(message));
       break;
+
     case 'sync':
-      this._batch(message);
+      this._batch(new Response(message)); 
       break;
+
     default:
-      this.emitNext(message.to, message);
+      this.emitNext(to, message);
   }
 };
 
 Client.prototype.emitNext = function() {
-  var args = Array.prototype.slice.call(arguments), client = this;
-  immediate(function(){ client.emit.apply(client, args); });
+  var args = Array.prototype.slice.call(arguments), self = this;
+  immediate(function(){ self.emit.apply(self, args); });
 };
 
 Client.prototype._identitySet = function () {
@@ -555,7 +797,7 @@ module.exports = Client;
 var props = [ 'set', 'get', 'subscribe', 'unsubscribe', 'publish', 'push', 'sync',
   'on', 'once', 'when', 'removeListener', 'removeAllListeners', 'nameSync'];
 
-var init = function(name) {
+var init = function (name) {
   Scope.prototype[name] = function () {
     var args = Array.prototype.slice.apply(arguments);
     args.unshift(this.prefix);
@@ -564,7 +806,7 @@ var init = function(name) {
   };
 };
 
-for(var i = 0; i < props.length; i++){
+for (var i = 0; i < props.length; i++){
   init(props[i]);
 }
 

--- a/lib/message_request.js
+++ b/lib/message_request.js
@@ -79,8 +79,9 @@ Request.buildUnsubscribe = function (scope, options) {
 // Instance methods
 
 Request.prototype.forceV2Sync = function (options) {
-  this.options = options || {};
-  this.options.version = 2;
+  options = options || {};
+  options.version = 2;
+  this.setAttr('options', options);
 };
 
 Request.prototype.setAuthData = function (configuration) {

--- a/lib/message_request.js
+++ b/lib/message_request.js
@@ -8,6 +8,9 @@ var opTable = {
   stream: ['get', 'push', 'subscribe', 'sync', 'unsubscribe']
 };
 
+// Avoids need for use of Object.keys (or backfill) on OpTable
+var opTableKeys = ['control', 'message', 'presence', 'status', 'stream'];
+
 var Request = function (operation, scope) {
   this.message = {
     op: operation,
@@ -20,10 +23,7 @@ var Request = function (operation, scope) {
 };
 
 Request.buildGet = function (scope, options) {
-  var request = new Request('get', scope);
-  request.setOptions(options);
-
-  return request;
+  return new Request('get', scope).setOptions(options);
 };
 
 Request.buildPublish = function (scope, value) {
@@ -43,27 +43,27 @@ Request.buildPush = function (scope, resource, action, value) {
 };
 
 Request.buildNameSync = function (scope, options) {
-  var request = new Request('nameSync', scope);
-  request.setOptions(options);
-
-  return request;
+  return new Request('nameSync', scope).setOptions(options);
 };
 
-Request.buildSet = function (scope, value, key, userType) {
+Request.buildSet = function (scope, value, clientData, key, userType) {
   var request = new Request('set', scope);
   request.setAttr('value', value);
+  if (clientData) {
+    request.setAttr('clientData', clientData);
+  }
   request.setAttr('key', key);
   request.setAttr('type', userType);
 
   return request;
 };
 
-Request.buildSync = function (scope) {
-  return new Request('sync', scope);
+Request.buildSync = function (scope, options) {
+  return new Request('sync', scope).setOptions(options);
 };
 
-Request.buildSubscribe = function (scope) {
-  return new Request('subscribe', scope);
+Request.buildSubscribe = function (scope, options) {
+  return new Request('subscribe', scope).setOptions(options);
 };
 
 Request.buildUnsubscribe = function (scope, options) {
@@ -72,7 +72,8 @@ Request.buildUnsubscribe = function (scope, options) {
 
 // TO DO: config class should return the required data via getters
 Request.prototype.setAuthData = function (configuration) {
-  if (configuration && configuration.auth) {
+  this.setAttr('userData', configuration.userData);
+  if (configuration.auth) {
     this.setAttr('auth', configuration.auth);
     this.setAttr('userId', configuration.userId);
     this.setAttr('userType', configuration.userType);
@@ -92,10 +93,7 @@ Request.prototype.getMessage = function () {
 
 Request.prototype.setOptions = function (options) {
   if (options) {
-    this.message.options = options;
-    this.message.options.version = 2;
-  } else {
-    this.message.options = { version: 1 };
+    this.setAttr('options', options);
   }
 
   return this;
@@ -121,6 +119,11 @@ Request.prototype.getVersion = function () {
   return this.message.options.version;
 };
 
+Request.prototype.payload = function () {
+  return JSON.stringify(this.getMessage());
+};
+
+
 // Private methods
 
 Request.prototype._isValid = function () {
@@ -139,12 +142,11 @@ Request.prototype._isValid = function () {
 };
 
 Request.prototype._isValidType = function () {
-  var types = Object.keys(opTable);
-  for (var i = 0; i < types.length; i++) {
-    if (types[i] === this.type) { return true; }
+  var isValid = opTableKeys.indexOf(this.type) >= 0;
+  if (!isValid) {
+    logger.error('invalid type: ' + this.type);
   }
-  logger.error('invalid type: ' + this.type);
-  return false;
+  return isValid;
 };
 
 Request.prototype._isValidOperation = function () {

--- a/lib/message_request.js
+++ b/lib/message_request.js
@@ -65,27 +65,13 @@ Request.buildUnsubscribe = function (scope, options) {
   return new Request('unsubscribe', scope);
 };
 
+// TO DO: config class should return the required data via getters
 Request.prototype.setAuthData = function (configuration) {
   if (configuration && configuration.auth) {
     this.setAttr('auth', configuration.auth);
     this.setAttr('userId', configuration.userId);
     this.setAttr('userType', configuration.userType);
     this.setAttr('accountName', configuration.accountName);
-  }
-};
-
-// TO DO: config class should return the required data via getters
-Request.setUserData_old = function (message, configuration) {
-  message.userData = configuration && configuration.userData;
-};
-
-// TO DO: config class should return the required data via getters
-Request.setAuthData_old = function (message, configuration) {
-  if (configuration && configuration.auth) {
-    message.auth = configuration.auth;
-    message.userId = configuration.userId;
-    message.userType = configuration.userType;
-    message.accountName = configuration.accountName;
   }
 };
 
@@ -132,13 +118,6 @@ Request.prototype.setAttrOptional = function (keyName, keyValue) {
   if (keyName && (keyValue === 0 || keyValue)) {
     this.message[keyName] = keyValue;
   }
-};
-
-Request.prototype.setAttr_old = function (keyName, keyValue) {
-  if (!keyName || !keyValue) {
-    throw new Error('Invalid request attribute');
-  }
-  this.message[keyName] = keyValue;
 };
 
 Request.prototype.getAttr = function (keyName) {

--- a/lib/message_request.js
+++ b/lib/message_request.js
@@ -1,0 +1,185 @@
+var logger = require('minilog')('message:request');
+
+var opTable = {
+  control: ['nameSync'],
+  message: ['publish', 'subscribe', 'sync', 'unsubscribe'],
+  presence: ['get', 'set', 'subscribe', 'sync', 'unsubscribe'],
+  status: ['get', 'set', 'subscribe', 'sync', 'unsubscribe'],
+  stream: ['get', 'push', 'subscribe', 'sync']
+};
+
+var Request = function (operation, scope) {
+  this.message = {
+    op: operation,
+    to: scope
+  };
+
+  if (!this._isValid()) {
+    throw new Error('Invalid request message.');
+  }
+};
+
+Request.buildGet = function (scope, options) {
+  return new Request('get', scope).setOptions(options);
+};
+
+Request.buildPublish = function (scope, value) {
+  var request = new Request('publish', scope);
+  request.setAttr('value', value);
+  return request;
+};
+
+Request.buildPush = function (scope, resource, action, value) {
+  var request = new Request('push', scope);
+  request.setAttr('resource', resource);
+  request.setAttr('action', action);
+  request.setAttr('value', value);
+
+  return request;
+};
+
+Request.buildNameSync = function (scope, options) {
+  return new Request('nameSync', scope).setOptions(options);
+};
+
+Request.buildSet = function (scope, value, clientData, key, userType) {
+  var request = new Request('set', scope);
+  request.setAttr('value', value);
+  request._setAttrOptionalDefined('key', key);
+  request._setAttrOptionalUndefined('type', userType);
+  if (typeof(clientData) != 'function') {
+    request._setAttrOptionalUndefined('clientData', clientData);
+  }
+  return request;
+};
+
+Request.buildSync = function (scope, options) {
+  return new Request('sync', scope).setOptions(options);
+};
+
+Request.buildSubscribe = function (scope, options) {
+  return new Request('subscribe', scope).setOptions(options);
+};
+
+Request.buildUnsubscribe = function (scope, options) {
+  return new Request('unsubscribe', scope);
+};
+
+Request.prototype.setAuthData = function (configuration) {
+  if (configuration && configuration.auth) {
+    this.setAttr('auth', configuration.auth);
+    this.setAttr('userId', configuration.userId);
+    this.setAttr('userType', configuration.userType);
+    this.setAttr('accountName', configuration.accountName);
+  }
+};
+
+// TO DO: config class should return the required data via getters
+Request.setUserData_old = function (message, configuration) {
+  message.userData = configuration && configuration.userData;
+};
+
+// TO DO: config class should return the required data via getters
+Request.setAuthData_old = function (message, configuration) {
+  if (configuration && configuration.auth) {
+    message.auth = configuration.auth;
+    message.userId = configuration.userId;
+    message.userType = configuration.userType;
+    message.accountName = configuration.accountName;
+  }
+};
+
+Request.getAttr = function (message, attr) {
+  return (message && message[attr]);
+};
+
+/*
+Request.setAttr = function (message, attr, value) {
+  if (message && attr) { message[attr] = value; }
+};
+*/
+
+// Instance methods
+
+Request.prototype.getMessage = function () {
+  return this.message;
+};
+
+Request.prototype.setOptions = function (options) {
+  if (options && typeof options != 'function') {
+    this.message.options = options;
+    this.version = 2;
+  } else {
+    this.version = 1;
+  }
+
+  return this;
+};
+
+Request.prototype.isPresence = function () {
+  return this.type === 'presence';
+};
+
+Request.prototype._setAttrOptionalUndefined = function (keyName, keyValue) {
+  if (keyName) {
+    this.message[keyName] = keyValue;
+  }
+};
+
+Request.prototype._setAttrOptionalDefined = function (keyName, keyValue) {
+  if (keyName && keyValue) {
+    this.message[keyName] = keyValue;
+  }
+};
+
+Request.prototype.setAttr = function (keyName, keyValue) {
+  if (!keyName || !keyValue) {
+    throw new Error('Invalid request attribute');
+  }
+  this.message[keyName] = keyValue;
+};
+
+Request.prototype.getAttr = function (keyName) {
+  if (keyName) {
+    return this.message[keyName];
+  }
+};
+
+Request.prototype.getVersion = function () {
+  return this.version;
+};
+
+// Private methods
+
+Request.prototype._isValid = function () {
+  if (!this.message.op || !this.message.to) {
+    return false;
+  }
+
+  var type = this._getType();
+  if (type) {
+    this.type = type;
+    return this._isValidType(type) && this._isValidOperation(type);
+  }
+  return false;
+};
+
+Request.prototype._isValidType = function () {
+  var types = Object.keys(opTable);
+  for (var i = 0; i < types.length; i++) {
+    if (types[i] === this.type) { return true; }
+  }
+  return false;
+};
+
+Request.prototype._isValidOperation = function () {
+  var ops = opTable[this.type];
+
+  return ops && ops.indexOf(this.message.op) >= 0;
+};
+
+Request.prototype._getType = function () {
+  return this.message.to.substring(0, this.message.to.indexOf(':'));
+};
+
+module.exports = Request;

--- a/lib/message_request.js
+++ b/lib/message_request.js
@@ -45,10 +45,10 @@ Request.buildNameSync = function (scope, options) {
 Request.buildSet = function (scope, value, clientData, key, userType) {
   var request = new Request('set', scope);
   request.setAttr('value', value);
-  request.setAttrOptionalDefined('key', key);
-  request.setAttrOptionalUndefined('type', userType);
+  request.setAttrOptional('key', key);
+  request.setAttrOptional('type', userType);
   if (typeof(clientData) != 'function') {
-    request.setAttrOptionalUndefined('clientData', clientData);
+    request.setAttrOptional('clientData', clientData);
   }
   return request;
 };
@@ -114,19 +114,27 @@ Request.prototype.isPresence = function () {
   return this.type === 'presence';
 };
 
-Request.prototype.setAttrOptionalUndefined = function (keyName, keyValue) {
-  if (keyName) {
-    this.message[keyName] = keyValue;
-  }
-};
-
-Request.prototype.setAttrOptionalDefined = function (keyName, keyValue) {
-  if (keyName && keyValue) {
+Request.prototype.setAttrOptional = function (keyName, keyValue) {
+  if (keyName && (keyValue === 0 || keyValue)) {
     this.message[keyName] = keyValue;
   }
 };
 
 Request.prototype.setAttr = function (keyName, keyValue) {
+  //if (!keyName || !keyValue) {
+  if (!(keyName && (keyValue === 0 || keyValue))) {
+    throw new Error('Invalid request attribute');
+  }
+  this.message[keyName] = keyValue;
+};
+
+Request.prototype.setAttrOptional = function (keyName, keyValue) {
+  if (keyName && (keyValue === 0 || keyValue)) {
+    this.message[keyName] = keyValue;
+  }
+};
+
+Request.prototype.setAttr_old = function (keyName, keyValue) {
   if (!keyName || !keyValue) {
     throw new Error('Invalid request attribute');
   }

--- a/lib/message_request.js
+++ b/lib/message_request.js
@@ -8,14 +8,8 @@ var opTable = {
   stream: ['get', 'push', 'subscribe', 'sync', 'unsubscribe']
 };
 
-// Avoids need for use of Object.keys (or backfill) on OpTable
-var opTableKeys = ['control', 'message', 'presence', 'status', 'stream'];
-
-var Request = function (operation, scope) {
-  this.message = {
-    op: operation,
-    to: scope
-  };
+var Request = function (message) {
+  this.message = message;
 
   if (!this._isValid()) {
     logger.error('invalid request. op: ' + this.op + '; to: ' + this.to);
@@ -23,18 +17,21 @@ var Request = function (operation, scope) {
 };
 
 Request.buildGet = function (scope, options) {
-  return new Request('get', scope).setOptions(options);
+  var message = { op: 'get', to: scope};
+  return new Request(message).setOptions(options);
 };
 
 Request.buildPublish = function (scope, value) {
-  var request = new Request('publish', scope);
+  var message = { op: 'publish', to: scope};
+  var request = new Request(message);
   request.setAttr('value', value);
 
   return request;
 };
 
 Request.buildPush = function (scope, resource, action, value) {
-  var request = new Request('push', scope);
+  var message = { op: 'push', to: scope};
+  var request = new Request(message);
   request.setAttr('resource', resource);
   request.setAttr('action', action);
   request.setAttr('value', value);
@@ -43,34 +40,40 @@ Request.buildPush = function (scope, resource, action, value) {
 };
 
 Request.buildNameSync = function (scope, options) {
-  return new Request('nameSync', scope).setOptions(options);
+  var message = { op: 'nameSync', to: scope};
+  return new Request(message).setOptions(options);
 };
 
-Request.buildSet = function (scope, value, clientData, key, userType) {
-  var request = new Request('set', scope);
+Request.buildSet = function (scope, value, key, userType, clientData) {
+  var message = { op: 'set', to: scope};
+  var request = new Request(message);
   request.setAttr('value', value);
+  request.setAttr('key', key);
+  request.setAttr('type', userType);
   if (clientData) {
     request.setAttr('clientData', clientData);
   }
-  request.setAttr('key', key);
-  request.setAttr('type', userType);
 
   return request;
 };
 
 Request.buildSync = function (scope, options) {
-  return new Request('sync', scope).setOptions(options);
+  var message = { op: 'sync', to: scope};
+  return new Request(message).setOptions(options);
 };
 
 Request.buildSubscribe = function (scope, options) {
-  return new Request('subscribe', scope).setOptions(options);
+  var message = { op: 'subscribe', to: scope};
+  return new Request(message).setOptions(options);
 };
 
 Request.buildUnsubscribe = function (scope, options) {
-  return new Request('unsubscribe', scope);
+  var message = { op: 'unsubscribe', to: scope};
+  return new Request(message);
 };
 
-// TO DO: config class should return the required data via getters
+// Instance methods
+
 Request.prototype.setAuthData = function (configuration) {
   this.setAttr('userData', configuration.userData);
   if (configuration.auth) {
@@ -81,12 +84,6 @@ Request.prototype.setAuthData = function (configuration) {
   }
 };
 
-Request.getAttr = function (message, attr) {
-  return (message && message[attr]);
-};
-
-// Instance methods
-
 Request.prototype.getMessage = function () {
   return this.message;
 };
@@ -94,6 +91,8 @@ Request.prototype.getMessage = function () {
 Request.prototype.setOptions = function (options) {
   if (options) {
     this.setAttr('options', options);
+  } else if (!options && this.isPresence() && this.getAttr('op') === 'sync') {
+    this.setAttr('options', { version: 2});
   }
 
   return this;
@@ -142,11 +141,13 @@ Request.prototype._isValid = function () {
 };
 
 Request.prototype._isValidType = function () {
-  var isValid = opTableKeys.indexOf(this.type) >= 0;
-  if (!isValid) {
-    logger.error('invalid type: ' + this.type);
+  for (var key in opTable) {
+    if (opTable.hasOwnProperty(key) && this.type == key) {
+      return true;
+    }
   }
-  return isValid;
+  logger.error('invalid type: ' + this.type);
+  return false;
 };
 
 Request.prototype._isValidOperation = function () {

--- a/lib/message_request.js
+++ b/lib/message_request.js
@@ -45,10 +45,10 @@ Request.buildNameSync = function (scope, options) {
 Request.buildSet = function (scope, value, clientData, key, userType) {
   var request = new Request('set', scope);
   request.setAttr('value', value);
-  request._setAttrOptionalDefined('key', key);
-  request._setAttrOptionalUndefined('type', userType);
+  request.setAttrOptionalDefined('key', key);
+  request.setAttrOptionalUndefined('type', userType);
   if (typeof(clientData) != 'function') {
-    request._setAttrOptionalUndefined('clientData', clientData);
+    request.setAttrOptionalUndefined('clientData', clientData);
   }
   return request;
 };
@@ -93,12 +93,6 @@ Request.getAttr = function (message, attr) {
   return (message && message[attr]);
 };
 
-/*
-Request.setAttr = function (message, attr, value) {
-  if (message && attr) { message[attr] = value; }
-};
-*/
-
 // Instance methods
 
 Request.prototype.getMessage = function () {
@@ -120,13 +114,13 @@ Request.prototype.isPresence = function () {
   return this.type === 'presence';
 };
 
-Request.prototype._setAttrOptionalUndefined = function (keyName, keyValue) {
+Request.prototype.setAttrOptionalUndefined = function (keyName, keyValue) {
   if (keyName) {
     this.message[keyName] = keyValue;
   }
 };
 
-Request.prototype._setAttrOptionalDefined = function (keyName, keyValue) {
+Request.prototype.setAttrOptionalDefined = function (keyName, keyValue) {
   if (keyName && keyValue) {
     this.message[keyName] = keyValue;
   }

--- a/lib/message_request.js
+++ b/lib/message_request.js
@@ -20,45 +20,61 @@ var Request = function (operation, scope) {
 };
 
 Request.buildGet = function (scope, options) {
-  return new Request('get', scope).setOptions(options);
+  var request = new Request('get', scope);
+  if (request) {
+    request.setOptions(options);
+  }
+
+  return request;
 };
 
 Request.buildPublish = function (scope, value) {
   var request = new Request('publish', scope);
-  request.setAttr('value', value);
+  if (request) {
+    request.setAttr('value', value);
+  }
+
   return request;
 };
 
 Request.buildPush = function (scope, resource, action, value) {
   var request = new Request('push', scope);
-  request.setAttr('resource', resource);
-  request.setAttr('action', action);
-  request.setAttr('value', value);
+  if (request) {
+    request.setAttr('resource', resource);
+    request.setAttr('action', action);
+    request.setAttr('value', value);
+  }
 
   return request;
 };
 
 Request.buildNameSync = function (scope, options) {
-  return new Request('nameSync', scope).setOptions(options);
-};
-
-Request.buildSet = function (scope, value, clientData, key, userType) {
-  var request = new Request('set', scope);
-  request.setAttr('value', value);
-  request.setAttr('key', key);
-  request.setAttr('type', userType);
-  if (typeof(clientData) != 'function') {
-    request.setAttr('clientData', clientData);
+  var request = new Request('nameSync', scope);
+  if (request) {
+    request.setOptions(options);
   }
+
   return request;
 };
 
-Request.buildSync = function (scope, options) {
-  return new Request('sync', scope).setOptions(options);
+Request.buildSet = function (scope, value, key, userType) {
+  var request = new Request('set', scope);
+
+  if (request) {
+    request.setAttr('value', value);
+    request.setAttr('key', key);
+    request.setAttr('type', userType);
+  }
+
+  return request;
 };
 
-Request.buildSubscribe = function (scope, options) {
-  return new Request('subscribe', scope).setOptions(options);
+Request.buildSync = function (scope) {
+  return new Request('sync', scope);
+};
+
+Request.buildSubscribe = function (scope) {
+  return new Request('subscribe', scope);
 };
 
 Request.buildUnsubscribe = function (scope, options) {
@@ -86,7 +102,7 @@ Request.prototype.getMessage = function () {
 };
 
 Request.prototype.setOptions = function (options) {
-  if (options && typeof(options) != 'function') {
+  if (options) {
     this.message.options = options;
     this.message.options.version = 2;
   } else {

--- a/lib/message_request.js
+++ b/lib/message_request.js
@@ -21,50 +21,39 @@ var Request = function (operation, scope) {
 
 Request.buildGet = function (scope, options) {
   var request = new Request('get', scope);
-  if (request) {
-    request.setOptions(options);
-  }
+  request.setOptions(options);
 
   return request;
 };
 
 Request.buildPublish = function (scope, value) {
   var request = new Request('publish', scope);
-  if (request) {
-    request.setAttr('value', value);
-  }
+  request.setAttr('value', value);
 
   return request;
 };
 
 Request.buildPush = function (scope, resource, action, value) {
   var request = new Request('push', scope);
-  if (request) {
-    request.setAttr('resource', resource);
-    request.setAttr('action', action);
-    request.setAttr('value', value);
-  }
+  request.setAttr('resource', resource);
+  request.setAttr('action', action);
+  request.setAttr('value', value);
 
   return request;
 };
 
 Request.buildNameSync = function (scope, options) {
   var request = new Request('nameSync', scope);
-  if (request) {
-    request.setOptions(options);
-  }
+  request.setOptions(options);
 
   return request;
 };
 
 Request.buildSet = function (scope, value, key, userType) {
   var request = new Request('set', scope);
-
-  if (request) {
-    request.setAttr('value', value);
-    request.setAttr('key', key);
-    request.setAttr('type', userType);
-  }
+  request.setAttr('value', value);
+  request.setAttr('key', key);
+  request.setAttr('type', userType);
 
   return request;
 };

--- a/lib/message_request.js
+++ b/lib/message_request.js
@@ -59,7 +59,11 @@ Request.buildSet = function (scope, value, key, userType, clientData) {
 
 Request.buildSync = function (scope, options) {
   var message = { op: 'sync', to: scope};
-  return new Request(message).setOptions(options);
+  var request = new Request(message).setOptions(options);
+  if (request.isPresence()) {
+    request.forceV2Sync(options);
+  }
+  return request;
 };
 
 Request.buildSubscribe = function (scope, options) {
@@ -73,6 +77,11 @@ Request.buildUnsubscribe = function (scope, options) {
 };
 
 // Instance methods
+
+Request.prototype.forceV2Sync = function (options) {
+  this.options = options || {};
+  this.options.version = 2;
+};
 
 Request.prototype.setAuthData = function (configuration) {
   this.setAttr('userData', configuration.userData);
@@ -89,10 +98,9 @@ Request.prototype.getMessage = function () {
 };
 
 Request.prototype.setOptions = function (options) {
+  // Keep check for options, since it is sometimes purposefully null
   if (options) {
     this.setAttr('options', options);
-  } else if (!options && this.isPresence() && this.getAttr('op') === 'sync') {
-    this.setAttr('options', { version: 2});
   }
 
   return this;
@@ -103,19 +111,11 @@ Request.prototype.isPresence = function () {
 };
 
 Request.prototype.setAttr = function (keyName, keyValue) {
-  if (keyName) {
-    this.message[keyName] = keyValue;
-  }
+  this.message[keyName] = keyValue;
 };
 
 Request.prototype.getAttr = function (keyName) {
-  if (keyName) {
-    return this.message[keyName];
-  }
-};
-
-Request.prototype.getVersion = function () {
-  return this.message.options.version;
+  return this.message[keyName];
 };
 
 Request.prototype.payload = function () {

--- a/lib/message_request.js
+++ b/lib/message_request.js
@@ -5,7 +5,7 @@ var opTable = {
   message: ['publish', 'subscribe', 'sync', 'unsubscribe'],
   presence: ['get', 'set', 'subscribe', 'sync', 'unsubscribe'],
   status: ['get', 'set', 'subscribe', 'sync', 'unsubscribe'],
-  stream: ['get', 'push', 'subscribe', 'sync']
+  stream: ['get', 'push', 'subscribe', 'sync', 'unsubscribe']
 };
 
 var Request = function (operation, scope) {
@@ -15,7 +15,7 @@ var Request = function (operation, scope) {
   };
 
   if (!this._isValid()) {
-    throw new Error('Invalid request message.');
+    logger.error('invalid request. op: ' + this.op + '; to: ' + this.to);
   }
 };
 
@@ -45,10 +45,10 @@ Request.buildNameSync = function (scope, options) {
 Request.buildSet = function (scope, value, clientData, key, userType) {
   var request = new Request('set', scope);
   request.setAttr('value', value);
-  request.setAttrOptional('key', key);
-  request.setAttrOptional('type', userType);
+  request.setAttr('key', key);
+  request.setAttr('type', userType);
   if (typeof(clientData) != 'function') {
-    request.setAttrOptional('clientData', clientData);
+    request.setAttr('clientData', clientData);
   }
   return request;
 };
@@ -86,11 +86,11 @@ Request.prototype.getMessage = function () {
 };
 
 Request.prototype.setOptions = function (options) {
-  if (options && typeof options != 'function') {
+  if (options && typeof(options) != 'function') {
     this.message.options = options;
-    this.version = 2;
+    this.message.options.version = 2;
   } else {
-    this.version = 1;
+    this.message.options = { version: 1 };
   }
 
   return this;
@@ -100,22 +100,8 @@ Request.prototype.isPresence = function () {
   return this.type === 'presence';
 };
 
-Request.prototype.setAttrOptional = function (keyName, keyValue) {
-  if (keyName && (keyValue === 0 || keyValue)) {
-    this.message[keyName] = keyValue;
-  }
-};
-
 Request.prototype.setAttr = function (keyName, keyValue) {
-  //if (!keyName || !keyValue) {
-  if (!(keyName && (keyValue === 0 || keyValue))) {
-    throw new Error('Invalid request attribute');
-  }
-  this.message[keyName] = keyValue;
-};
-
-Request.prototype.setAttrOptional = function (keyName, keyValue) {
-  if (keyName && (keyValue === 0 || keyValue)) {
+  if (keyName) {
     this.message[keyName] = keyValue;
   }
 };
@@ -127,7 +113,7 @@ Request.prototype.getAttr = function (keyName) {
 };
 
 Request.prototype.getVersion = function () {
-  return this.version;
+  return this.message.options.version;
 };
 
 // Private methods
@@ -141,6 +127,8 @@ Request.prototype._isValid = function () {
   if (type) {
     this.type = type;
     return this._isValidType(type) && this._isValidOperation(type);
+  } else {
+    logger.error('missing type');
   }
   return false;
 };
@@ -150,13 +138,18 @@ Request.prototype._isValidType = function () {
   for (var i = 0; i < types.length; i++) {
     if (types[i] === this.type) { return true; }
   }
+  logger.error('invalid type: ' + this.type);
   return false;
 };
 
 Request.prototype._isValidOperation = function () {
   var ops = opTable[this.type];
 
-  return ops && ops.indexOf(this.message.op) >= 0;
+  var isValid = ops && ops.indexOf(this.message.op) >= 0;
+  if (!isValid) {
+    logger.error('invalid operation for type: ' + this.type);
+  }
+  return isValid;
 };
 
 Request.prototype._getType = function () {

--- a/lib/message_response.js
+++ b/lib/message_response.js
@@ -1,11 +1,7 @@
 var logger = require('minilog')('message:response');
 
 function Response (message) {
-  if (typeof(message) === 'string') {
-    this.message = JSON.parse(message);
-  } else {
-    this.message = message;
-  }
+  this.message = message;
   this.validate();
 }
 
@@ -19,16 +15,20 @@ Response.prototype.getMessage = function () {
 
 Response.prototype.validate = function () {
   if (!this.message.op) {
-    _throwError('missing op');
+    logger.error('missing op');
   }
 
   switch(this.message.op) {
     case 'ack':
-      if (!this.message.value) { _throwError('missing value'); }
+      if (!this.message.value) {
+        logger.error('missing value');
+      }
       break;
 
     default:
-      if (this.message.op != 'err' && !this.message.to) { _throwError('missing to'); }
+      if (this.message.op != 'err' && !this.message.to) {
+        logger.error('missing to');
+      }
   }
 };
 
@@ -58,10 +58,6 @@ Response.prototype.forceV2Presence = function () {
   }
   message.value = value;
   message.op = 'online';
-};
-
-var _throwError = function (errMessage) {
-  throw new Error('response: ' + errMessage);
 };
 
 module.exports = Response;

--- a/lib/message_response.js
+++ b/lib/message_response.js
@@ -1,0 +1,67 @@
+var logger = require('minilog')('message:response');
+
+function Response (message) {
+  if (typeof(message) === 'string') {
+    this.message = JSON.parse(message);
+  } else {
+    this.message = message;
+  }
+  this.validate();
+}
+
+Response.getAttr = function (message, attr) {
+  return message && message[attr];
+};
+
+Response.prototype.getMessage = function () {
+  return this.message;
+};
+
+Response.prototype.validate = function () {
+  if (!this.message.op) {
+    _throwError('missing op');
+  }
+
+  switch(this.message.op) {
+    case 'ack':
+      if (!this.message.value) { _throwError('missing value'); }
+      break;
+
+    default:
+      if (this.message.op != 'err' && !this.message.to) { _throwError('missing to'); }
+  }
+};
+
+Response.prototype.isValid = function (request) {
+  if (this.getAttr('op') === 'ack') {
+    return this.getAttr('value') === request.getAttr('ack');
+  } else {
+    return this.getAttr('to') === request.getAttr('to');
+  }
+};
+
+Response.prototype.getAttr = function (attr) {
+  return this.message[attr];
+};
+
+Response.prototype.forceV2Presence = function () {
+  // Sync v1 for presence scopes is inconsistent: the result should be a 'get'
+  // message, but instead is an 'online' message.  Take a v2 response and
+  // massage it to v1 format prior to returning to the caller.
+  var message = this.message, value = {}, userId;
+  for (userId in message.value) {
+    if (message.value.hasOwnProperty(userId)) {
+      // Skip when not defined; causes exception in FF for 'Work Offline'
+      if (!message.value[userId]) { continue; }
+      value[userId] = message.value[userId].userType;
+    }
+  }
+  message.value = value;
+  message.op = 'online';
+};
+
+var _throwError = function (errMessage) {
+  throw new Error('response: ' + errMessage);
+};
+
+module.exports = Response;

--- a/lib/message_response.js
+++ b/lib/message_response.js
@@ -15,7 +15,7 @@ Response.prototype.getMessage = function () {
 
 Response.prototype.validate = function () {
   if (!this.message.op) {
-    logger.error('missing op');
+    return;
   }
 
   switch(this.message.op) {
@@ -33,18 +33,28 @@ Response.prototype.validate = function () {
 };
 
 Response.prototype.isValid = function (request) {
-  if (this.getAttr('op') === 'ack') {
+  if (!request) {
+    return !!this.message.to && !!this.message.value && !!this.message.time;
+  } else if (this.getAttr('op') === 'ack') {
     return this.getAttr('value') === request.getAttr('ack');
   } else {
     return this.getAttr('to') === request.getAttr('to');
   }
 };
 
+Response.prototype.isFor = function (request) {
+  return this.getAttr('to') === request.getAttr('to');
+};
+
+Response.prototype.isAckFor = function (request) {
+  return this.getAttr('value') === request.getAttr('ack');
+};
+
 Response.prototype.getAttr = function (attr) {
   return this.message[attr];
 };
 
-Response.prototype.forceV2Presence = function () {
+Response.prototype.forceV1Response = function () {
   // Sync v1 for presence scopes is inconsistent: the result should be a 'get'
   // message, but instead is an 'online' message.  Take a v2 response and
   // massage it to v1 format prior to returning to the caller.

--- a/lib/message_response.js
+++ b/lib/message_response.js
@@ -5,10 +5,6 @@ function Response (message) {
   this.validate();
 }
 
-Response.getAttr = function (message, attr) {
-  return message && message[attr];
-};
-
 Response.prototype.getMessage = function () {
   return this.message;
 };

--- a/lib/radar_client.js
+++ b/lib/radar_client.js
@@ -149,9 +149,14 @@ Client.prototype.push = function(scope, resource, action, value, callback) {
 };
 
 Client.prototype.set = function(scope, value, clientData, callback) {
-  callback = callbackSet(callback, clientData);
-  var request = Request.buildSet(scope, value, clientData,
+  var request = Request.buildSet(scope, value,
                   this._configuration.userId, this._configuration.userType);
+  if (typeof(clientData) === 'function') {
+    callback = clientData;
+  } else if (request) {
+    request.setAttr('clientData', clientData);
+  }
+
   return this._write(request, callback);
 };
 
@@ -161,8 +166,9 @@ Client.prototype.publish = function(scope, value, callback) {
 };
 
 Client.prototype.subscribe = function(scope, options, callback) {
-  callback = callbackSet(callback, options);
-  var request = Request.buildSubscribe(scope, options);
+  var request = Request.buildSubscribe(scope);
+  callback = _callbackOptionsSet(request, options, callback);
+
   return this._write(request, callback);
 };
 
@@ -171,15 +177,12 @@ Client.prototype.unsubscribe = function(scope, callback) {
   return this._write(request, callback);
 };
 
-var callbackSet = function (callback, options) {
-  if (typeof options === 'function') { callback = options; }
-  return callback;
-};
-
 // sync returns the actual value of the operation
 Client.prototype.sync = function (scope, options, callback) {
-  var request = Request.buildSync(scope, options);
-  callback = callbackSet(callback, options);
+  var request = Request.buildSync(scope);
+  if (!request) { return; }
+
+  callback = _callbackOptionsSet(request, options, callback);
 
   var v1Presence = request.getVersion() === 1 && request.isPresence();
   var onResponse = function (response) {
@@ -205,6 +208,9 @@ Client.prototype.sync = function (scope, options, callback) {
 // get returns the actual value of the operation
 Client.prototype.get = function (scope, options, callback) {
   var request = Request.buildGet(scope, options);
+  if (!request) { return; }
+
+  callback = _callbackOptionsSet(request, options, callback);
 
   var onResponse = function (response) {
     if (response && response.getAttr('to') === request.getAttr('to')) {
@@ -216,7 +222,6 @@ Client.prototype.get = function (scope, options, callback) {
     return false;
   };
 
-  callback = callbackSet(callback, options);
   this.when('get', onResponse);
 
   // get does not return ACK (it sends back a data message)
@@ -224,6 +229,19 @@ Client.prototype.get = function (scope, options, callback) {
 };
 
 // Private API
+
+var _callbackOptionsSet = function (request, options, callback) {
+  if (request) {
+    if (typeof(options) === 'function') {
+      callback = options;
+      request.setOptions();
+    } else {
+      request.setOptions(options);
+    }
+  }
+
+  return callback;
+};
 
 Client.prototype._addListeners = function () {
   // Add authentication data to a request message; _write() emits authenticateMessage

--- a/lib/radar_client.js
+++ b/lib/radar_client.js
@@ -114,29 +114,26 @@ Client.prototype.currentClientId = function() {
   return this._socket && this._socket.id;
 };
 
-// Return the scope object for a given message type
+// Return the chainable scope object for a given message type
 
 Client.prototype.message = function(scope) {
-  return new Scope(_buildScopeName('message', this._configuration, scope), this);
+  return new Scope('message', scope, this);
 };
 
-// Access the "presence" chainable operations
 Client.prototype.presence = function(scope) {
-  return new Scope(_buildScopeName('presence', this._configuration, scope), this);
+  return new Scope('presence', scope, this);
 };
 
-// Access the "status" chainable operations
 Client.prototype.status = function(scope) {
-  return new Scope(_buildScopeName('status', this._configuration, scope), this);
+  return new Scope('status', scope, this);
 };
 
 Client.prototype.stream = function(scope) {
-  return new Scope(_buildScopeName('stream', this._configuration, scope), this);
+  return new Scope('stream', scope, this);
 };
 
-// Access the "control" chainable operations
 Client.prototype.control = function(scope) {
-  return new Scope(_buildScopeName('control', this._configuration, scope), this);
+  return new Scope('control', scope, this);
 };
 
 // Operations
@@ -225,10 +222,6 @@ Client.prototype.get = function (scope, options, callback) {
 };
 
 // Private API
-
-var _buildScopeName = function (type, configuration, scope) {
-  return type + ':/' + configuration.accountName + '/' + scope;
-};
 
 Client.prototype._addListeners = function () {
   // Add authentication data to a request message; _write() emits authenticateMessage

--- a/lib/radar_client.js
+++ b/lib/radar_client.js
@@ -179,10 +179,12 @@ var callbackSet = function (callback, options) {
 // sync returns the actual value of the operation
 Client.prototype.sync = function (scope, options, callback) {
   var request = Request.buildSync(scope, options);
+  callback = callbackSet(callback, options);
 
-  var whenCallback = function (response) {
+  var v1Presence = request.getVersion() === 1 && request.isPresence();
+  var onResponse = function (response) {
     if (response && response.getAttr('to') === request.getAttr('to')) {
-      if (request.getVersion() === 1 && request.isPresence()) {
+      if (v1Presence) {
         response.forceV2Presence();
       }
       if (callback) {
@@ -193,8 +195,8 @@ Client.prototype.sync = function (scope, options, callback) {
     return false;
   };
 
-  callback = callbackSet(callback, options);
-  this.when('get', whenCallback);
+  if (v1Presence) { request.setOptions({ version: 2 }); }
+  this.when('get', onResponse);
 
   // sync does not return ACK (it sends back a data message)
   return this._write(request);
@@ -204,7 +206,7 @@ Client.prototype.sync = function (scope, options, callback) {
 Client.prototype.get = function (scope, options, callback) {
   var request = Request.buildGet(scope, options);
 
-  var whenCallback = function (response) {
+  var onResponse = function (response) {
     if (response && response.getAttr('to') === request.getAttr('to')) {
       if (callback) {
         callback(response.getMessage());
@@ -215,7 +217,7 @@ Client.prototype.get = function (scope, options, callback) {
   };
 
   callback = callbackSet(callback, options);
-  this.when('get', whenCallback);
+  this.when('get', onResponse);
 
   // get does not return ACK (it sends back a data message)
   return this._write(request);
@@ -226,7 +228,7 @@ Client.prototype.get = function (scope, options, callback) {
 Client.prototype._addListeners = function () {
   // Add authentication data to a request message; _write() emits authenticateMessage
   this.on('authenticateMessage', function(request) {
-    request.setAttr('userData', this._configuration);
+    request.setAttr('userData', this._configuration.userData);
     request.setAuthData(this._configuration);
 
     this.emit('messageAuthenticated', request);
@@ -241,19 +243,23 @@ Client.prototype._addListeners = function () {
 Client.prototype._write = function(request, callback) {
   var self = this;
 
-  if (callback) {
-    request.setAttr('ack', this._ackCounter++);
+  if (request) {
+    if (callback) {
+      request.setAttr('ack', this._ackCounter++);
 
-    // Wait ack
-    this.when('ack', function(response) {
-      self.logger().debug('ack', response);
-      if (response.getAttr('value') != request.getAttr('ack')) { return false; }
-      callback(request.getMessage());
+      // Wait ack
+      this.when('ack', function(response) {
+        self.logger().debug('ack', response);
+        if (response.getAttr('value') != request.getAttr('ack')) { return false; }
+        callback(request.getMessage());
 
-      return true;
-    });
+        return true;
+      });
+    }
+
+    this.emit('authenticateMessage', request);
   }
-  this.emit('authenticateMessage', request);
+
   return this;
 };
 
@@ -437,6 +443,7 @@ Client.prototype._messageReceived = function (msg) {
     case 'err':
     case 'ack':
     case 'get':
+      var response = new Response(message);
       this.emitNext(op, new Response(message));
       break;
 
@@ -463,8 +470,11 @@ Client.prototype._identitySet = function () {
   var association = { id : this._socket.id, name: this.name };
   var clientVersion = getClientVersion();
   var options = { association: association, clientVersion: clientVersion };
+  var self = this;
 
-  this.control('clientName').nameSync(options);
+  this.control('clientName').nameSync(options, function (message) {
+    self.logger('nameSync message: ' + JSON.stringify(message));
+  });
 }; 
 
 // Variant (by Jeff Ward) of code behind node-uuid, but avoids need for module

--- a/lib/radar_client.js
+++ b/lib/radar_client.js
@@ -149,13 +149,13 @@ Client.prototype.push = function(scope, resource, action, value, callback) {
 };
 
 Client.prototype.set = function(scope, value, clientData, callback) {
-  var request = Request.buildSet(scope, value,
+  var request;
+
+  callback = _chooseFunction(clientData, callback);
+  clientData = _nullIfFunction(clientData);
+
+  request = Request.buildSet(scope, value, clientData,
                   this._configuration.userId, this._configuration.userType);
-  if (typeof(clientData) === 'function') {
-    callback = clientData;
-  } else if (request) {
-    request.setAttr('clientData', clientData);
-  }
 
   return this._write(request, callback);
 };
@@ -166,8 +166,10 @@ Client.prototype.publish = function(scope, value, callback) {
 };
 
 Client.prototype.subscribe = function(scope, options, callback) {
-  var request = Request.buildSubscribe(scope);
-  callback = _callbackOptionsSet(request, options, callback);
+  callback = _chooseFunction(options, callback);
+  options = _nullIfFunction(options);
+
+  var request = Request.buildSubscribe(scope, options);
 
   return this._write(request, callback);
 };
@@ -179,16 +181,19 @@ Client.prototype.unsubscribe = function(scope, callback) {
 
 // sync returns the actual value of the operation
 Client.prototype.sync = function (scope, options, callback) {
-  var request = Request.buildSync(scope);
-  if (!request) { return; }
+  var request, onResponse, v1Presence;
 
-  callback = _callbackOptionsSet(request, options, callback);
+  callback = _chooseFunction(options, callback);
+  options = _nullIfFunction(options);
 
-  var v1Presence = request.getVersion() === 1 && request.isPresence();
-  var onResponse = function (response) {
-    if (response && response.getAttr('to') === request.getAttr('to')) {
+  request = Request.buildSync(scope, options);
+
+  //v1Presence = request.getVersion() === 1 && request.isPresence();
+  v1Presence = !options && request.isPresence();
+  onResponse = function (response) {
+    if (response && response.isFor(request)) {
       if (v1Presence) {
-        response.forceV2Presence();
+        response.forceV1Response();
       }
       if (callback) {
         callback(response.getMessage());
@@ -198,7 +203,8 @@ Client.prototype.sync = function (scope, options, callback) {
     return false;
   };
 
-  if (v1Presence) { request.setOptions({ version: 2 }); }
+  if (v1Presence) { request.setAttr('options', { version: 2 }); }
+  //if (v1Presence) { request.setOptions({ version: 2 }); }
   this.when('get', onResponse);
 
   // sync does not return ACK (it sends back a data message)
@@ -207,13 +213,15 @@ Client.prototype.sync = function (scope, options, callback) {
 
 // get returns the actual value of the operation
 Client.prototype.get = function (scope, options, callback) {
-  var request = Request.buildGet(scope, options);
-  if (!request) { return; }
+  var request;
 
-  callback = _callbackOptionsSet(request, options, callback);
+  callback = _chooseFunction(options, callback);
+  options = _nullIfFunction(options);
+
+  request = Request.buildGet(scope, options);
 
   var onResponse = function (response) {
-    if (response && response.getAttr('to') === request.getAttr('to')) {
+    if (response && response.isFor(request)) {
       if (callback) {
         callback(response.getMessage());
       }
@@ -230,23 +238,20 @@ Client.prototype.get = function (scope, options, callback) {
 
 // Private API
 
-var _callbackOptionsSet = function (request, options, callback) {
-  if (request) {
-    if (typeof(options) === 'function') {
-      callback = options;
-      request.setOptions();
-    } else {
-      request.setOptions(options);
-    }
-  }
+var _chooseFunction = function (options, callback) {
+  return typeof(options) === 'function' ? options : callback;
+};
 
-  return callback;
+var _nullIfFunction = function (options) {
+  if (typeof(options) === 'function') {
+    return null;
+  }
+  return options;
 };
 
 Client.prototype._addListeners = function () {
   // Add authentication data to a request message; _write() emits authenticateMessage
   this.on('authenticateMessage', function(request) {
-    request.setAttr('userData', this._configuration.userData);
     request.setAuthData(this._configuration);
 
     this.emit('messageAuthenticated', request);
@@ -261,22 +266,20 @@ Client.prototype._addListeners = function () {
 Client.prototype._write = function(request, callback) {
   var self = this;
 
-  if (request) {
-    if (callback) {
-      request.setAttr('ack', this._ackCounter++);
+  if (callback) {
+    request.setAttr('ack', this._ackCounter++);
 
-      // Wait ack
-      this.when('ack', function(response) {
-        self.logger().debug('ack', response);
-        if (response.getAttr('value') != request.getAttr('ack')) { return false; }
-        callback(request.getMessage());
+    // Wait ack
+    this.when('ack', function(response) {
+      self.logger().debug('ack', response);
+      if (!response.isAckFor(request)) { return false; }
+      callback(request.getMessage());
 
-        return true;
-      });
-    }
-
-    this.emit('authenticateMessage', request);
+      return true;
+    });
   }
+
+  this.emit('authenticateMessage', request);
 
   return this;
 };
@@ -286,7 +289,7 @@ Client.prototype._batch = function(response) {
       value = response.getAttr('value'),
       time = response.getAttr('time');
 
-  if (!to || !value || !time) {
+  if (!response.isValid()) {
     return false;
   }
 
@@ -440,7 +443,7 @@ Client.prototype._sendMessage = function(request) {
   this.emit('message:out', request.getMessage());
 
   if (this._socket && this.manager.is('activated')) {
-    this._socket.sendPacket('message', JSON.stringify(request.getMessage()));
+    this._socket.sendPacket('message', request.payload());
   } else if (this._isConfigured) {
     this._restoreRequired = true;
     if (!memorized || ack) {
@@ -451,26 +454,25 @@ Client.prototype._sendMessage = function(request) {
 };
 
 Client.prototype._messageReceived = function (msg) {
-  var message = JSON.parse(msg),
-      op = Response.getAttr(message, 'op'),
-      to = Response.getAttr(message, 'to');
+  var response = new Response(JSON.parse(msg)),
+      op = response.getAttr('op'),
+      to = response.getAttr('to');
 
-  this.emit('message:in', message);
+  this.emit('message:in', response.getMessage());
 
   switch (op) {
     case 'err':
     case 'ack':
     case 'get':
-      var response = new Response(message);
-      this.emitNext(op, new Response(message));
+      this.emitNext(op, response);
       break;
 
     case 'sync':
-      this._batch(new Response(message)); 
+      this._batch(response);
       break;
 
     default:
-      this.emitNext(to, message);
+      this.emitNext(to, response.getMessage());
   }
 };
 

--- a/lib/radar_client.js
+++ b/lib/radar_client.js
@@ -18,7 +18,7 @@ function Client(backend) {
   this._presences = {};
   this._subscriptions = {};
   this._restoreRequired = false;
-  this._queuedMessages = [];
+  this._queuedRequests = [];
   this._isConfigured = false;
 
   this._createManager();
@@ -154,8 +154,9 @@ Client.prototype.set = function(scope, value, clientData, callback) {
   callback = _chooseFunction(clientData, callback);
   clientData = _nullIfFunction(clientData);
 
-  request = Request.buildSet(scope, value, clientData,
-                  this._configuration.userId, this._configuration.userType);
+  request = Request.buildSet(scope, value,
+                  this._configuration.userId, this._configuration.userType,
+                  clientData);
 
   return this._write(request, callback);
 };
@@ -188,9 +189,9 @@ Client.prototype.sync = function (scope, options, callback) {
 
   request = Request.buildSync(scope, options);
 
-  //v1Presence = request.getVersion() === 1 && request.isPresence();
   v1Presence = !options && request.isPresence();
-  onResponse = function (response) {
+  onResponse = function (message) {
+    var response = new Response(message);
     if (response && response.isFor(request)) {
       if (v1Presence) {
         response.forceV1Response();
@@ -203,8 +204,6 @@ Client.prototype.sync = function (scope, options, callback) {
     return false;
   };
 
-  if (v1Presence) { request.setAttr('options', { version: 2 }); }
-  //if (v1Presence) { request.setOptions({ version: 2 }); }
   this.when('get', onResponse);
 
   // sync does not return ACK (it sends back a data message)
@@ -220,7 +219,8 @@ Client.prototype.get = function (scope, options, callback) {
 
   request = Request.buildGet(scope, options);
 
-  var onResponse = function (response) {
+  var onResponse = function (message) {
+    var response = new Response(message);
     if (response && response.isFor(request)) {
       if (callback) {
         callback(response.getMessage());
@@ -251,14 +251,16 @@ var _nullIfFunction = function (options) {
 
 Client.prototype._addListeners = function () {
   // Add authentication data to a request message; _write() emits authenticateMessage
-  this.on('authenticateMessage', function(request) {
+  this.on('authenticateMessage', function(message) {
+    var request = new Request(message);
     request.setAuthData(this._configuration);
 
-    this.emit('messageAuthenticated', request);
+    this.emit('messageAuthenticated', request.getMessage());
   });
 
   // Once the request is authenticated, send it to the server
-  this.on('messageAuthenticated', function(request) {
+  this.on('messageAuthenticated', function(message) {
+    var request = new Request(message);
     this._sendMessage(request);
   });
 };
@@ -270,7 +272,8 @@ Client.prototype._write = function(request, callback) {
     request.setAttr('ack', this._ackCounter++);
 
     // Wait ack
-    this.when('ack', function(response) {
+    this.when('ack', function(message) {
+      var response = new Response(message);
       self.logger().debug('ack', response);
       if (!response.isAckFor(request)) { return false; }
       callback(request.getMessage());
@@ -279,7 +282,7 @@ Client.prototype._write = function(request, callback) {
     });
   }
 
-  this.emit('authenticateMessage', request);
+  this.emit('authenticateMessage', request.getMessage());
 
   return this;
 };
@@ -290,6 +293,7 @@ Client.prototype._batch = function(response) {
       time = response.getAttr('time');
 
   if (!response.isValid()) {
+    this.logger().info('response is invalid:', response.getMessage());
     return false;
   }
 
@@ -392,13 +396,14 @@ Client.prototype._memorize = function(request) {
 
     case 'sync':
     case 'subscribe':
+      // A catch for when *subscribe* is called after *sync*
       if (this._subscriptions[to] != 'sync') {
         this._subscriptions[to] = op;
       }
       return true;
 
     case 'set':
-      if (to.substr(0, 'presence:/'.length) == 'presence:/') {
+      if (request.isPresence()) {
         this._presences[to] = value;
         return true;
       }
@@ -427,8 +432,8 @@ Client.prototype._restore = function() {
       }
     }
 
-    while (this._queuedMessages.length) {
-      this._write(this._queuedMessages.shift());
+    while (this._queuedRequests.length) {
+      this._write(this._queuedRequests.shift());
       counts.messages += 1;
     }
 
@@ -447,7 +452,7 @@ Client.prototype._sendMessage = function(request) {
   } else if (this._isConfigured) {
     this._restoreRequired = true;
     if (!memorized || ack) {
-      this._queuedMessages.push(request);
+      this._queuedRequests.push(request);
     }
     this.manager.connectWhenAble();
   }
@@ -464,7 +469,7 @@ Client.prototype._messageReceived = function (msg) {
     case 'err':
     case 'ack':
     case 'get':
-      this.emitNext(op, response);
+      this.emitNext(op, response.getMessage());
       break;
 
     case 'sync':

--- a/lib/radar_client.js
+++ b/lib/radar_client.js
@@ -5,7 +5,9 @@ var MicroEE = require('microee'),
     StateMachine = require('./state.js'),
     immediate = typeof setImmediate != 'undefined' ? setImmediate :
                                     function(fn) { setTimeout(fn, 1); },
-    getClientVersion = require('./client_version.js');
+    getClientVersion = require('./client_version.js'),
+    Request = require('./message_request.js'),
+    Response = require('./message_response.js');
 
 function Client(backend) {
   var self = this;
@@ -112,235 +114,207 @@ Client.prototype.currentClientId = function() {
   return this._socket && this._socket.id;
 };
 
+// Return the scope object for a given message type
+
 Client.prototype.message = function(scope) {
-  return new Scope('message:/'+this._configuration.accountName+'/'+scope, this);
+  return new Scope(_buildScopeName('message', this._configuration, scope), this);
 };
 
 // Access the "presence" chainable operations
 Client.prototype.presence = function(scope) {
-  return new Scope('presence:/'+this._configuration.accountName+'/'+scope, this);
+  return new Scope(_buildScopeName('presence', this._configuration, scope), this);
 };
 
 // Access the "status" chainable operations
 Client.prototype.status = function(scope) {
-  return new Scope('status:/'+this._configuration.accountName+'/'+scope, this);
+  return new Scope(_buildScopeName('status', this._configuration, scope), this);
 };
 
 Client.prototype.stream = function(scope) {
-  return new Scope('stream:/'+this._configuration.accountName+'/'+scope, this);
+  return new Scope(_buildScopeName('stream', this._configuration, scope), this);
 };
 
 // Access the "control" chainable operations
 Client.prototype.control = function(scope) {
-  return new Scope('control:/'+this._configuration.accountName+'/'+scope, this);
+  return new Scope(_buildScopeName('control', this._configuration, scope), this);
 };
 
+// Operations
+
 Client.prototype.nameSync = function(scope, options, callback) {
-  var message = { op: 'nameSync', to: scope };
-  if (typeof options == 'function') {
-    callback = options;
-  } else {
-    message.options = options;
-  }
-  return this._write(message, callback);
+  var request = Request.buildNameSync(scope, options);
+  return this._write(request, callback);
 };
 
 Client.prototype.push = function(scope, resource, action, value, callback) {
-  return this._write({
-    op: 'push',
-    to: scope,
-    resource: resource,
-    action: action,
-    value: value
-  }, callback);
+  var request = Request.buildPush(scope, resource, action, value);
+  return this._write(request, callback);
 };
 
 Client.prototype.set = function(scope, value, clientData, callback) {
-  var message = {
-    op: 'set',
-    to: scope,
-    value: value,
-    key: this._configuration.userId,
-    type: this._configuration.userType
-  };
-
-  if (typeof(clientData) === 'function') {
-    callback = clientData;
-  } else {
-    message.clientData = clientData;
-  }
-
-  return this._write(message, callback);
+  callback = callbackSet(callback, clientData);
+  var request = Request.buildSet(scope, value, clientData,
+                  this._configuration.userId, this._configuration.userType);
+  return this._write(request, callback);
 };
 
 Client.prototype.publish = function(scope, value, callback) {
-  return this._write({
-    op: 'publish',
-    to: scope,
-    value: value
-  }, callback);
+  var request = Request.buildPublish(scope, value);
+  return this._write(request, callback);
 };
 
 Client.prototype.subscribe = function(scope, options, callback) {
-  var message = { op: 'subscribe', to: scope };
-  if (typeof options == 'function') {
-    callback = options;
-  } else {
-    message.options = options;
-  }
-  return this._write(message, callback);
+  callback = callbackSet(callback, options);
+  var request = Request.buildSubscribe(scope, options);
+  return this._write(request, callback);
 };
 
 Client.prototype.unsubscribe = function(scope, callback) {
-  return this._write({ op: 'unsubscribe', to: scope }, callback);
+  var request = Request.buildUnsubscribe(scope);
+  return this._write(request, callback);
 };
 
-// Sync and get return the actual value of the operation
-var init = function(propertyName) {
-  Client.prototype[propertyName] = function(scope, options, callback) {
-    var message = { op: propertyName, to: scope };
-    // options is an optional argument
-    if (typeof options == 'function') {
-      callback = options;
-    } else {
-      message.options = options;
-    }
-    // Sync v1 for presence scopes acts inconsistently. The result should be a
-    // "get" message, but it is actually a "online" message.
-    // So force v2 and translate the result to v1 format.
-    if (propertyName == 'sync' && !message.options && scope.match(/^presence.+/)) {
-      message.options = { version: 2 };
-      this.when('get', function(message) {
-        var value = {}, userId;
-        if (!message || !message.to || message.to != scope) {
-          return false;
-        }
+var callbackSet = function (callback, options) {
+  if (typeof options === 'function') { callback = options; }
+  return callback;
+};
 
-        for (userId in message.value) {
-          if (message.value.hasOwnProperty(userId)) {
-            // Skip when not defined; causes exception in FF for 'Work Offline'
-            if (!message.value[userId]) { continue; }
-            value[userId] = message.value[userId].userType;
-          }
-        }
-        message.value = value;
-        message.op = 'online';
-        if (callback) {
-          callback(message);
-        }
-        return true;
-      });
-    } else {
-      this.when('get', function(message) {
-        if (!message || !message.to || message.to != scope) {
-          return false;
-        }
-        if (callback) {
-          callback(message);
-        }
-        return true;
-      });
+// sync returns the actual value of the operation
+Client.prototype.sync = function (scope, options, callback) {
+  var request = Request.buildSync(scope, options);
+
+  var whenCallback = function (response) {
+    if (response && response.getAttr('to') === request.getAttr('to')) {
+      if (request.getVersion() === 1 && request.isPresence()) {
+        response.forceV2Presence();
+      }
+      if (callback) {
+        callback(response.getMessage());
+      }
+      return true;
     }
-    // sync/get never register or return acks (since they always send back a
-    // data message)
-    return this._write(message);
+    return false;
   };
+
+  callback = callbackSet(callback, options);
+  this.when('get', whenCallback);
+
+  // sync does not return ACK (it sends back a data message)
+  return this._write(request);
 };
 
-var props = ['get', 'sync'];
-for(var i = 0; i < props.length; i++){
-  init(props[i]);
-}
+// get returns the actual value of the operation
+Client.prototype.get = function (scope, options, callback) {
+  var request = Request.buildGet(scope, options);
+
+  var whenCallback = function (response) {
+    if (response && response.getAttr('to') === request.getAttr('to')) {
+      if (callback) {
+        callback(response.getMessage());
+      }
+      return true;
+    }
+    return false;
+  };
+
+  callback = callbackSet(callback, options);
+  this.when('get', whenCallback);
+
+  // get does not return ACK (it sends back a data message)
+  return this._write(request);
+};
 
 // Private API
 
+var _buildScopeName = function (type, configuration, scope) {
+  return type + ':/' + configuration.accountName + '/' + scope;
+};
+
 Client.prototype._addListeners = function () {
-  // Add authentication data to a message; _write() emits authenticateMessage
-  this.on('authenticateMessage', function(message) {
-    if (this._configuration) {
-      message.userData = this._configuration.userData;
-      if (this._configuration.auth) {
-        message.auth = this._configuration.auth;
-        message.userId = this._configuration.userId;
-        message.userType = this._configuration.userType;
-        message.accountName = this._configuration.accountName;
-      }
-    }
-    this.emit('messageAuthenticated', message);
+  // Add authentication data to a request message; _write() emits authenticateMessage
+  this.on('authenticateMessage', function(request) {
+    request.setAttr('userData', this._configuration);
+    request.setAuthData(this._configuration);
+
+    this.emit('messageAuthenticated', request);
   });
 
-  // Once the message is authenticated, send it to the server
-  this.on('messageAuthenticated', function(message) {
-    this._sendMessage(message);
+  // Once the request is authenticated, send it to the server
+  this.on('messageAuthenticated', function(request) {
+    this._sendMessage(request);
   });
 };
 
-Client.prototype._write = function(message, callback) {
-  var client = this;
+Client.prototype._write = function(request, callback) {
+  var self = this;
 
   if (callback) {
-    message.ack = this._ackCounter++;
+    request.setAttr('ack', this._ackCounter++);
+
     // Wait ack
-    this.when('ack', function(m) {
-      client.logger().debug('ack', m);
-      if (!m || !m.value || m.value != message.ack) {
-        return false;
-      }
-      callback(message);
+    this.when('ack', function(response) {
+      self.logger().debug('ack', response);
+      if (response.getAttr('value') != request.getAttr('ack')) { return false; }
+      callback(request.getMessage());
+
       return true;
     });
   }
-  this.emit('authenticateMessage', message);
+  this.emit('authenticateMessage', request);
   return this;
 };
 
-Client.prototype._batch = function(message) {
-  if (!(message.to && message.value && message.time)) {
+Client.prototype._batch = function(response) {
+  var to = response.getAttr('to'),
+      value = response.getAttr('value'),
+      time = response.getAttr('time');
+
+  if (!to || !value || !time) {
     return false;
   }
 
-  var index = 0, data, time,
-      length = message.value.length,
-      newest = message.time,
-      current = this._channelSyncTimes[message.to] || 0;
+  var index = 0, data,
+      length = value.length,
+      newest = time,
+      current = this._channelSyncTimes[to] || 0;
 
   for (; index < length; index = index + 2) {
-    data = JSON.parse(message.value[index]);
-    time = message.value[index + 1];
+    data = JSON.parse(value[index]);
+    time = value[index + 1];
 
     if (time > current) {
-      this.emitNext(message.to, data);
+      this.emitNext(to, data);
     }
     if (time > newest) {
       newest = time;
     }
   }
-  this._channelSyncTimes[message.to] = newest;
+  this._channelSyncTimes[to] = newest;
 };
 
 Client.prototype._createManager = function() {
-  var client = this, manager = this.manager = StateMachine.create();
+  var self = this, manager = this.manager = StateMachine.create();
 
   manager.on('enterState', function(state) {
-    client.emit(state);
+    self.emit(state);
   });
 
   manager.on('event', function(event) {
-    client.emit(event);
+    self.emit(event);
   });
 
   manager.on('connect', function(data) {
-    var socket = client._socket = new client.backend.Socket(client._configuration);
+    var socket = self._socket = new self.backend.Socket(self._configuration);
 
     socket.once('open', function() {
-      client.logger().debug("socket open", socket.id);
+      self.logger().debug("socket open", socket.id);
       manager.established();
     });
 
     socket.once('close', function(reason, description) {
-      client.logger().debug('socket closed', socket.id, reason, description);
+      self.logger().debug('socket closed', socket.id, reason, description);
       socket.removeAllListeners('message');
-      client._socket = null;
+      self._socket = null;
 
       // Patch for polling-xhr continuing to poll after socket close (HTTP:POST
       // failure).  socket.transport is in error but not closed, so if a subsequent
@@ -355,8 +329,8 @@ Client.prototype._createManager = function() {
       }
     });
 
-    socket.on('message', function(message) {
-      client._messageReceived(message);
+    socket.on('message', function (message) {
+      self._messageReceived(message);
     });
 
     manager.removeAllListeners('close');
@@ -366,9 +340,9 @@ Client.prototype._createManager = function() {
   });
 
   manager.on('activate', function() {
-    client._identitySet();
-    client._restore();
-    client.emit('ready');
+    self._identitySet();
+    self._restore();
+    self.emit('ready');
   });
 
   manager.on('authenticate', function() {
@@ -377,40 +351,46 @@ Client.prototype._createManager = function() {
   });
 
   manager.on('disconnect', function() {
-    client._restoreRequired = true;
+    self._restoreRequired = true;
   });
 };
 
 // Memorize subscriptions and presence states; return "true" for a message that
 // adds to the memorized subscriptions or presences
-Client.prototype._memorize = function(message) {
-  switch(message.op) {
+Client.prototype._memorize = function(request) {
+  var op = request.getAttr('op'),
+      to = request.getAttr('to'),
+      value = request.getAttr('value');
+
+  switch(op) {
     case 'unsubscribe':
       // Remove from queue
-      if (this._subscriptions[message.to]) {
-        delete this._subscriptions[message.to];
+      if (this._subscriptions[to]) {
+        delete this._subscriptions[to];
       }
       return true;
+
     case 'sync':
     case 'subscribe':
-      if (this._subscriptions[message.to] != 'sync') {
-        this._subscriptions[message.to] = message.op;
+      if (this._subscriptions[to] != 'sync') {
+        this._subscriptions[to] = op;
       }
       return true;
+
     case 'set':
-      if (message.to.substr(0, 'presence:/'.length) == 'presence:/') {
-        this._presences[message.to] = message.value;
+      if (to.substr(0, 'presence:/'.length) == 'presence:/') {
+        this._presences[to] = value;
         return true;
       }
   }
+
   return false;
 };
 
 Client.prototype._restore = function() {
-  var item, i, to, message, counts = { subscriptions: 0, presences: 0, messages: 0 };
+  var item, to, counts = { subscriptions: 0, presences: 0, messages: 0 };
   if (this._restoreRequired) {
     this._restoreRequired = false;
-
 
     for (to in this._subscriptions) {
       if (this._subscriptions.hasOwnProperty(to)) {
@@ -436,41 +416,49 @@ Client.prototype._restore = function() {
   }
 };
 
-Client.prototype._sendMessage = function(message) {
-  var memorized = this._memorize(message);
-  this.emit('message:out', message);
+Client.prototype._sendMessage = function(request) {
+  var memorized = this._memorize(request),
+      ack = request.getAttr('ack');
+
+  this.emit('message:out', request.getMessage());
 
   if (this._socket && this.manager.is('activated')) {
-    this._socket.sendPacket('message', JSON.stringify(message));
+    this._socket.sendPacket('message', JSON.stringify(request.getMessage()));
   } else if (this._isConfigured) {
     this._restoreRequired = true;
-    if (!memorized || message.ack) {
-      this._queuedMessages.push(message);
+    if (!memorized || ack) {
+      this._queuedMessages.push(request);
     }
     this.manager.connectWhenAble();
   }
 };
 
 Client.prototype._messageReceived = function (msg) {
-  var message = JSON.parse(msg);
+  var message = JSON.parse(msg),
+      op = Response.getAttr(message, 'op'),
+      to = Response.getAttr(message, 'to');
+
   this.emit('message:in', message);
-  switch (message.op) {
+
+  switch (op) {
     case 'err':
     case 'ack':
     case 'get':
-      this.emitNext(message.op, message);
+      this.emitNext(op, new Response(message));
       break;
+
     case 'sync':
-      this._batch(message);
+      this._batch(new Response(message)); 
       break;
+
     default:
-      this.emitNext(message.to, message);
+      this.emitNext(to, message);
   }
 };
 
 Client.prototype.emitNext = function() {
-  var args = Array.prototype.slice.call(arguments), client = this;
-  immediate(function(){ client.emit.apply(client, args); });
+  var args = Array.prototype.slice.call(arguments), self = this;
+  immediate(function(){ self.emit.apply(self, args); });
 };
 
 Client.prototype._identitySet = function () {

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -1,6 +1,6 @@
-function Scope(prefix, client) {
-  this.prefix = prefix;
+function Scope(typeName, scope, client) {
   this.client = client;
+  this.prefix = this._buildScopePrefix(typeName, scope, client._configuration);
 }
 
 var props = [ 'set', 'get', 'subscribe', 'unsubscribe', 'publish', 'push', 'sync',
@@ -15,8 +15,12 @@ var init = function (name) {
   };
 };
 
-for (var i = 0; i < props.length; i++){
+for (var i = 0; i < props.length; i++) {
   init(props[i]);
 }
+
+Scope.prototype._buildScopePrefix = function (typeName, scope, configuration) {
+  return typeName + ':/' + configuration.accountName + '/' + scope;
+};
 
 module.exports = Scope;

--- a/lib/scope.js
+++ b/lib/scope.js
@@ -6,7 +6,7 @@ function Scope(prefix, client) {
 var props = [ 'set', 'get', 'subscribe', 'unsubscribe', 'publish', 'push', 'sync',
   'on', 'once', 'when', 'removeListener', 'removeAllListeners', 'nameSync'];
 
-var init = function(name) {
+var init = function (name) {
   Scope.prototype[name] = function () {
     var args = Array.prototype.slice.apply(arguments);
     args.unshift(this.prefix);
@@ -15,7 +15,7 @@ var init = function(name) {
   };
 };
 
-for(var i = 0; i < props.length; i++){
+for (var i = 0; i < props.length; i++){
   init(props[i]);
 }
 

--- a/scripts/run_radar_tests
+++ b/scripts/run_radar_tests
@@ -1,7 +1,7 @@
 #! /bin/bash
 
 # clone a radar repo
-git clone -b pobrien/radar_test_changes_for_message_protocol_v2 git@github.com:zendesk/radar.git
+git clone git@github.com:zendesk/radar.git
 # link this version of client
 npm link
 cd radar

--- a/scripts/run_radar_tests
+++ b/scripts/run_radar_tests
@@ -1,7 +1,7 @@
 #! /bin/bash
 
 # clone a radar repo
-git clone https://github.com/zendesk/radar.git
+git clone -b pobrien/radar_test_changes_for_message_protocol_v2 git@github.com:zendesk/radar.git
 # link this version of client
 npm link
 cd radar

--- a/scripts/run_radar_tests
+++ b/scripts/run_radar_tests
@@ -1,7 +1,7 @@
 #! /bin/bash
 
 # clone a radar repo
-git clone git@github.com:zendesk/radar.git
+git clone https://github.com/zendesk/radar.git
 # link this version of client
 npm link
 cd radar

--- a/tests/radar_client.test.js
+++ b/tests/radar_client.test.js
@@ -81,7 +81,6 @@ exports['after reconnecting'] = {
         key: 123,
         type: 2,
         userData: undefined
-        //clientData: undefined
       });
     });
 

--- a/tests/radar_client.test.js
+++ b/tests/radar_client.test.js
@@ -80,8 +80,8 @@ exports['after reconnecting'] = {
         value: 'online',
         key: 123,
         type: 2,
-        userData: undefined,
-        clientData: undefined
+        userData: undefined
+        //clientData: undefined
       });
     });
 

--- a/tests/radar_client.test.js
+++ b/tests/radar_client.test.js
@@ -80,7 +80,8 @@ exports['after reconnecting'] = {
         value: 'online',
         key: 123,
         type: 2,
-        userData: { accountName: 'test', userId: 123, userType: 2 }
+        userData: undefined,
+        clientData: undefined
       });
     });
 

--- a/tests/radar_client.test.js
+++ b/tests/radar_client.test.js
@@ -80,8 +80,7 @@ exports['after reconnecting'] = {
         value: 'online',
         key: 123,
         type: 2,
-        userData: { accountName: 'test', userId: 123, userType: 2 },
-        clientData: undefined
+        userData: { accountName: 'test', userId: 123, userType: 2 }
       });
     });
 
@@ -315,43 +314,6 @@ exports['given a new presence'] = {
       done();
     }, 10);
   },
-
-  /*
-  'synchronization batch filters out duplicate messages to the same channel by time': function(done) {
-    var received = [];
-    client.on('foo', function(msg) {
-      received.push(msg);
-    });
-    client._batch({
-      to: 'foo',
-      value: [
-        JSON.stringify({ value: 'a' }),
-        1,
-        JSON.stringify({ value: 'b' }),
-        2,
-        JSON.stringify({ value: 'c' }),
-        3
-      ],
-      time: 1
-    });
-    client._batch({
-      to: 'foo',
-      value: [
-        JSON.stringify({ value: 'b' }),
-        2,
-        JSON.stringify({ value: 'c' }),
-        3,
-        JSON.stringify({ value: 'd' }),
-        600,
-      ],
-      time: 2
-    });
-    setTimeout(function() {
-      assert.equal(4, received.length);
-      done();
-    }, 10);
-  }
-  */
 
   'synchronization batch filters out duplicate messages to the same channel by time': function(done) {
     var received = [],

--- a/tests/radar_client.test.js
+++ b/tests/radar_client.test.js
@@ -73,8 +73,8 @@ exports['after reconnecting'] = {
     client.once('connect', function() {
       connected = true;
       assert.equal(MockEngine.current._written.length, 1);
-      assert.equal(client._queuedMessages.length, 1);
-      assert.deepEqual(client._queuedMessages[0].message, {
+      assert.equal(client._queuedRequests.length, 1);
+      assert.deepEqual(client._queuedRequests[0].message, {
         op: 'set',
         to: 'status:/test/tickets/21',
         value: 'online',
@@ -87,7 +87,7 @@ exports['after reconnecting'] = {
 
     client.once('ready', function() {
       assert.ok(connected);
-      assert.equal(client._queuedMessages.length, 0);
+      assert.equal(client._queuedRequests.length, 0);
       assert.ok(
         MockEngine.current._written.some(function(message) {
           return message.op == 'set' &&

--- a/tests/radar_client.unit.test.js
+++ b/tests/radar_client.unit.test.js
@@ -192,8 +192,7 @@ exports.RadarClient = {
         called = true;
         assert.deepEqual(request.getMessage(), {
           op: 'subscribe',
-          to: 'status:/test/account/1',
-          options: { version: 1 }
+          to: 'status:/test/account/1'
         });
         assert.equal(fn, callback);
       };
@@ -281,8 +280,7 @@ exports.RadarClient = {
         called = true;
         assert.deepEqual(request.getMessage(), {
           op: 'get',
-          to: 'status:/test/account/1',
-          options: { version: 1 }
+          to: 'status:/test/account/1'
         });
       };
 
@@ -351,8 +349,7 @@ exports.RadarClient = {
         called = true;
         assert.deepEqual(request.getMessage(), {
           op: 'sync',
-          to: 'status:/test/account/1',
-          options: { version: 1 }
+          to: 'status:/test/account/1'
         });
       };
 
@@ -599,8 +596,8 @@ exports.RadarClient = {
     '._write': {
       'should emit an authenticateMessage event': function() {
         var called = false,
-            message = { op: 'subscribe', to: 'status:/account/scope/1', options: { version: 1 }},
-            request = Request.buildSubscribe(message.to).setOptions();
+            message = { op: 'subscribe', to: 'status:/account/scope/1'},
+            request = Request.buildSubscribe(message.to);
 
         client.emit = function(name, data) {
           called = true;

--- a/tests/radar_client.unit.test.js
+++ b/tests/radar_client.unit.test.js
@@ -193,6 +193,7 @@ exports.RadarClient = {
         assert.deepEqual(hash.message, {
           op: 'subscribe',
           to: 'status:/test/account/1',
+          options: { version: 1 }
         });
         assert.equal(fn, callback);
       };
@@ -280,7 +281,8 @@ exports.RadarClient = {
         called = true;
         assert.deepEqual(hash.message, {
           op: 'get',
-          to: 'status:/test/account/1'
+          to: 'status:/test/account/1',
+          options: { version: 1 }
         });
       };
 
@@ -349,7 +351,8 @@ exports.RadarClient = {
         called = true;
         assert.deepEqual(hash.message, {
           op: 'sync',
-          to: 'status:/test/account/1'
+          to: 'status:/test/account/1',
+          options: { version: 1 }
         });
       };
 
@@ -596,7 +599,7 @@ exports.RadarClient = {
     '._write': {
       'should emit an authenticateMessage event': function() {
         var called = false,
-            message = { op: 'subscribe', to: 'status:/account/scope/1' },
+            message = { op: 'subscribe', to: 'status:/account/scope/1', options: { version: 1 }},
             request = Request.buildSubscribe(message.to);
 
         client.emit = function(name, data) {
@@ -659,10 +662,7 @@ exports.RadarClient = {
           var message = { to: 'status:/dev/ticket/1', value: 'x', time: new Date() / 1000 },
               response;
           
-          assert.throws(function ()
-            { response = new Response(message); },
-            /missing op/
-          );
+          response = new Response(message);
           assert.deepEqual(client._channelSyncTimes, {});
         },
 
@@ -670,10 +670,7 @@ exports.RadarClient = {
           var message = { op: 'subscribe', value: 'x', time: new Date() / 1000 },
               response;
           
-          assert.throws(function ()
-            { response = new Response(message); },
-            /missing to/
-          );
+          response = new Response(message);
           assert.deepEqual(client._channelSyncTimes, {});
         },
 

--- a/tests/radar_client.unit.test.js
+++ b/tests/radar_client.unit.test.js
@@ -126,9 +126,9 @@ exports.RadarClient = {
     'should call _write() with a set operation definition hash': function() {
       var called = false, callback = function(){};
 
-      client._write = function(hash, fn) {
+      client._write = function(request, fn) {
         called = true;
-        assert.deepEqual(hash.message, {
+        assert.deepEqual(request.getMessage(), {
           op: 'set',
           to: 'status:/test/account/1',
           value: 'whatever',
@@ -168,9 +168,9 @@ exports.RadarClient = {
     'should call _write() with a publish operation definition hash': function() {
       var called = false, callback = function(){};
 
-      client._write = function(hash, fn) {
+      client._write = function(request, fn) {
         called = true;
-        assert.deepEqual(hash.message, {
+        assert.deepEqual(request.getMessage(), {
           op: 'publish',
           to: 'message:/test/account/1',
           value: 'whatever'
@@ -188,9 +188,9 @@ exports.RadarClient = {
     'should call _write() with a subscribe operation definition hash': function() {
       var called = false, callback = function(){};
 
-      client._write = function(hash, fn) {
+      client._write = function(request, fn) {
         called = true;
-        assert.deepEqual(hash.message, {
+        assert.deepEqual(request.getMessage(), {
           op: 'subscribe',
           to: 'status:/test/account/1',
           options: { version: 1 }
@@ -238,9 +238,9 @@ exports.RadarClient = {
     'should call _write() with a unsubscribe operation definition hash': function() {
       var called = false, callback = function(){};
 
-      client._write = function(hash, fn) {
+      client._write = function(request, fn) {
         called = true;
-        assert.deepEqual(hash.message, {
+        assert.deepEqual(request.getMessage(), {
           op: 'unsubscribe',
           to: 'status:/test/account/1',
         });
@@ -277,9 +277,9 @@ exports.RadarClient = {
     'should call _write() with a get operation definition hash': function() {
       var called = false;
 
-      client._write = function(hash) {
+      client._write = function(request) {
         called = true;
-        assert.deepEqual(hash.message, {
+        assert.deepEqual(request.getMessage(), {
           op: 'get',
           to: 'status:/test/account/1',
           options: { version: 1 }
@@ -347,9 +347,9 @@ exports.RadarClient = {
     'should call _write() with a sync operation definition hash': function() {
       var called = false;
 
-      client._write = function(hash) {
+      client._write = function(request) {
         called = true;
-        assert.deepEqual(hash.message, {
+        assert.deepEqual(request.getMessage(), {
           op: 'sync',
           to: 'status:/test/account/1',
           options: { version: 1 }
@@ -600,7 +600,7 @@ exports.RadarClient = {
       'should emit an authenticateMessage event': function() {
         var called = false,
             message = { op: 'subscribe', to: 'status:/account/scope/1', options: { version: 1 }},
-            request = Request.buildSubscribe(message.to);
+            request = Request.buildSubscribe(message.to).setOptions();
 
         client.emit = function(name, data) {
           called = true;

--- a/tests/radar_client.unit.test.js
+++ b/tests/radar_client.unit.test.js
@@ -1,6 +1,8 @@
 var assert = require('assert'),
     RadarClient = require('../lib/radar_client.js'),
     MockEngine = require('./lib/engine.js'),
+    Request = require('../lib/message_request.js'),
+    Response = require('../lib/message_response.js'),
     HOUR = 1000 * 60 * 60,
     client;
 
@@ -126,7 +128,7 @@ exports.RadarClient = {
 
       client._write = function(hash, fn) {
         called = true;
-        assert.deepEqual(hash, {
+        assert.deepEqual(hash.message, {
           op: 'set',
           to: 'status:/test/account/1',
           value: 'whatever',
@@ -168,16 +170,16 @@ exports.RadarClient = {
 
       client._write = function(hash, fn) {
         called = true;
-        assert.deepEqual(hash, {
+        assert.deepEqual(hash.message, {
           op: 'publish',
-          to: 'status:/test/account/1',
+          to: 'message:/test/account/1',
           value: 'whatever'
         });
         assert.equal(fn, callback);
       };
 
       client.configure({ accountName: 'test', userId: 123, userType: 0 });
-      client.publish('status:/test/account/1', 'whatever', callback);
+      client.publish('message:/test/account/1', 'whatever', callback);
       assert.ok(called);
     }
   },
@@ -188,7 +190,7 @@ exports.RadarClient = {
 
       client._write = function(hash, fn) {
         called = true;
-        assert.deepEqual(hash, {
+        assert.deepEqual(hash.message, {
           op: 'subscribe',
           to: 'status:/test/account/1',
         });
@@ -237,7 +239,7 @@ exports.RadarClient = {
 
       client._write = function(hash, fn) {
         called = true;
-        assert.deepEqual(hash, {
+        assert.deepEqual(hash.message, {
           op: 'unsubscribe',
           to: 'status:/test/account/1',
         });
@@ -276,10 +278,9 @@ exports.RadarClient = {
 
       client._write = function(hash) {
         called = true;
-        assert.deepEqual(hash, {
+        assert.deepEqual(hash.message, {
           op: 'get',
-          to: 'status:/test/account/1',
-          options: undefined
+          to: 'status:/test/account/1'
         });
       };
 
@@ -303,7 +304,8 @@ exports.RadarClient = {
       var called = false,
           passed = false,
           scope = 'status:/test/account/1',
-          message = { to: scope },
+          message = { op: 'get', to: scope },
+          response = new Response(message),
           callback = function(msg) {
             passed = true;
             assert.deepEqual(msg, message);
@@ -311,7 +313,7 @@ exports.RadarClient = {
 
       client.when = function(operation, fn) {
         called = true;
-        fn(message);
+        fn(response);
       };
 
       client.get(scope, callback);
@@ -322,14 +324,15 @@ exports.RadarClient = {
     'should pass a function that will not call the callback function for a get response operation with a different scope': function() {
       var called = false,
           passed = true,
-          message = { to: 'status:/test/account/2' },
+          message = { op: 'get', to: 'status:/test/account/2' },
+          response = new Response(message),
           callback = function(msg) {
             passed = false;
           };
 
       client.when = function(operation, fn) {
         called = true;
-        fn(message);
+        fn(response);
       };
 
       client.get('status:/test/account/1', callback);
@@ -344,10 +347,9 @@ exports.RadarClient = {
 
       client._write = function(hash) {
         called = true;
-        assert.deepEqual(hash, {
+        assert.deepEqual(hash.message, {
           op: 'sync',
-          to: 'status:/test/account/1',
-          options: undefined
+          to: 'status:/test/account/1'
         });
       };
 
@@ -372,7 +374,8 @@ exports.RadarClient = {
         var called = false,
             passed = false,
             scope = 'presence:/test/account/1',
-            message = { to: scope },
+            message = { op: 'sync', to: scope },
+            response = new Response(message),
             callback = function(msg) {
               passed = true;
               assert.deepEqual(msg, message);
@@ -380,7 +383,7 @@ exports.RadarClient = {
 
         client.when = function(operation, fn) {
           called = true;
-          fn(message);
+          fn(response);
         };
 
         client.sync(scope, { version: 2 }, callback);
@@ -391,14 +394,15 @@ exports.RadarClient = {
       'should pass a function that will not call the callback function for a get response operation with a different scope': function() {
         var called = false,
             passed = true,
-            message = { to: 'presence:/test/account/2' },
+            message = { op: 'sync', to: 'presence:/test/account/2' },
+            response = new Response(message),
             callback = function(msg) {
               passed = false;
             };
 
         client.when = function(operation, fn) {
           called = true;
-          fn(message);
+          fn(response);
         };
 
         client.sync('presence:/test/account/1', { version: 2 }, callback);
@@ -426,29 +430,36 @@ exports.RadarClient = {
         // Previous online emits should not affect the callback
         client.emit(scope, { op: 'online', to: scope, value: { 100: 2 } });
 
-        client.emit('get', {
+        var message = {
           op: 'get', to: scope,
           value: {
             100: { userType: 2, clients: {} },
             200: { userType: 0, clients: {} }
           }
-        });
+        };
+
+        var response = new Response(message);
+        client.emit('get', response);
       }
     }
   },
 
-
   'internal methods': {
     '_memorize' : {
       'memorizing a sync/subscribe should work': function(done) {
+        var request;
+
         assert.equal(0, Object.keys(client._subscriptions).length);
-        client._memorize({ op: 'subscribe', to: 'foo'});
+        request = Request.buildSubscribe('presence:/test/ticket/1');
+        client._memorize(request);
         assert.equal(1, Object.keys(client._subscriptions).length);
 
-        client._memorize({ op: 'sync', to: 'bar'});
+        request = Request.buildSync('status:/test/ticket/1');
+        client._memorize(request);
         assert.equal(2, Object.keys(client._subscriptions).length);
 
-        client._memorize({ op: 'get', to: 'bar' });
+        request = Request.buildGet('status:/test/ticket/1');
+        client._memorize(request);
         // Should be a no-op
         assert.equal(2, Object.keys(client._subscriptions).length);
 
@@ -456,15 +467,19 @@ exports.RadarClient = {
       },
 
       'memorizing a set(online) and unmemorizing a set(offline) should work': function(done) {
+        var request;
+
         assert.equal(0, Object.keys(client._presences).length);
-        client._memorize({ op: 'set', to: 'presence:/foo/bar', value: 'online' });
+        request = Request.buildSet('presence:/foo/bar', 'online');
+        client._memorize(request);
         assert.equal('online', client._presences['presence:/foo/bar']);
         assert.equal(1, Object.keys(client._presences).length);
         // Duplicate should be ignored
-        client._memorize({ op: 'set', to: 'presence:/foo/bar', value: 'online' });
+        client._memorize(request);
         assert.equal(1, Object.keys(client._presences).length);
 
-        client._memorize({ op: 'set', to: 'presence:/foo/bar', value: 'offline' });
+        request = Request.buildSet('presence:/foo/bar', 'offline');
+        client._memorize(request);
         assert.equal(1, Object.keys(client._presences).length);
         assert.equal('offline', client._presences['presence:/foo/bar']);
         done();
@@ -472,58 +487,72 @@ exports.RadarClient = {
 
       'memorizing a unsubscribe should remove any sync/subscribe': function(done) {
         // Set up
-        client._memorize({ op: 'subscribe', to: 'foo'});
-        client._memorize({ op: 'sync', to: 'bar'});
+        var request = Request.buildSubscribe('status:/test/ticket/1');
+        client._memorize(request);
+        request = Request.buildSync('status:/test/ticket/2');
+        client._memorize(request);
         assert.equal(2, Object.keys(client._subscriptions).length);
+
         // Unsubscribe
-        client._memorize({ op: 'unsubscribe', to: 'foo'});
+        request = Request.buildUnsubscribe('status:/test/ticket/1');
+        client._memorize(request);
         assert.equal(1, Object.keys(client._subscriptions).length);
-        client._memorize({ op: 'unsubscribe', to: 'bar'});
+        request = Request.buildUnsubscribe('status:/test/ticket/2');
+        client._memorize(request);
         assert.equal(0, Object.keys(client._subscriptions).length);
         done();
       },
 
       'duplicated subscribes and syncs should only be stored once and sync is more important than subscribe': function(done) {
         // Simple duplicates
-        client._memorize({ op: 'subscribe', to: 'foo'});
+        var request = Request.buildSubscribe('status:/test/ticket/1');
+        client._memorize(request);
         assert.equal(1, Object.keys(client._subscriptions).length);
-        client._memorize({ op: 'subscribe', to: 'foo'});
+        client._memorize(request);
         assert.equal(1, Object.keys(client._subscriptions).length);
 
 
         client._subscriptions = {};
         // Simple duplicates
-        client._memorize({ op: 'sync', to: 'abc'});
+        request = Request.buildSync('status:/test/ticket/2');
+        client._memorize(request);
         assert.equal(1, Object.keys(client._subscriptions).length);
-        client._memorize({ op: 'sync', to: 'abc'});
+        client._memorize(request);
         assert.equal(1, Object.keys(client._subscriptions).length);
 
         client._subscriptions = {};
         // Sync after subscribe
-        client._memorize({ op: 'sync', to: 'bar'});
+        request = Request.buildSubscribe('status:/test/ticket/3');
+        client._memorize(request);
         assert.equal(1, Object.keys(client._subscriptions).length);
-        client._memorize({ op: 'sync', to: 'bar'});
+        request = Request.buildSync('status:/test/ticket/3');
+        client._memorize(request);
         assert.equal(1, Object.keys(client._subscriptions).length);
-        assert.equal('sync', client._subscriptions.bar);
+        assert.equal('sync', client._subscriptions['status:/test/ticket/3']);
 
         client._subscriptions = {};
         // Subscribe after sync
-        client._memorize({ op: 'sync', to: 'baz'});
+        request = Request.buildSync('status:/test/ticket/4');
+        client._memorize(request);
         assert.equal(1, Object.keys(client._subscriptions).length);
-        assert.equal('sync', client._subscriptions.baz);
+        assert.equal('sync', client._subscriptions['status:/test/ticket/4']);
         // When we sync and subscribe, it means just sync
-        client._memorize({ op: 'subscribe', to: 'baz'});
+        request = Request.buildSubscribe('status:/test/ticket/4');
+        client._memorize(request);
         assert.equal(1, Object.keys(client._subscriptions).length);
-        assert.equal('sync', client._subscriptions.baz);
+        assert.equal('sync', client._subscriptions['status:/test/ticket/4']);
 
         done();
       }
     },
+
     '_restore' : {
       'restore presences' : function(done){
         MockEngine.current._written = [];
-        client._memorize({ op: 'set', to: 'presence:/foo/bar', value: 'online' });
-        client._memorize({ op: 'set', to: 'presence:/foo/bar2', value: 'offline' });
+        var request = Request.buildSet('presence:/foo/bar', 'online');
+        client._memorize(request);
+        request = Request.buildSet('presence:/foo/bar2', 'offline');
+        client._memorize(request);
         client._restoreRequired = true;
         client.configure({ accountName: 'foo', userId: 123, userType: 2 });
         client.alloc('test', function() {
@@ -541,10 +570,13 @@ exports.RadarClient = {
           done();
         });
       },
+
       'restore subscriptions' : function(done){
         MockEngine.current._written = [];
-        client._memorize({ op: 'subscribe', to: 'status:/foo/bar' });
-        client._memorize({ op: 'subscribe', to: 'message:/foo/bar2' });
+        var request = Request.buildSubscribe('status:/foo/bar');
+        client._memorize(request);
+        request = Request.buildSubscribe('message:/foo/bar2');
+        client._memorize(request);
         client._restoreRequired = true;
         client.configure({ accountName: 'foo', userId: 123, userType: 2 });
         client.alloc('test', function() {
@@ -564,7 +596,8 @@ exports.RadarClient = {
     '._write': {
       'should emit an authenticateMessage event': function() {
         var called = false,
-            message = { op: 'something', to: 'wherever:/account/scope/1' };
+            message = { op: 'subscribe', to: 'status:/account/scope/1' },
+            request = Request.buildSubscribe(message.to);
 
         client.emit = function(name, data) {
           called = true;
@@ -572,28 +605,30 @@ exports.RadarClient = {
           assert.deepEqual(data, message);
         };
 
-        client._write(message);
+        client._write(request.getMessage());
         assert.ok(called);
       },
 
       'should register an ack event handler that calls the callback function once the appropriate ack message has been received': function() {
         var called = false,
             passed = false,
-            message = { op: 'something', to: 'wherever:/account/scope/1' },
+            request = Request.buildSubscribe('status:/account/scope/1'),
             ackMessage = { value: -2 },
             callback = function(msg) {
               passed = true;
-              assert.deepEqual(msg, message);
+              assert.deepEqual(msg, request.getMessage());
             };
 
         client.when = function(name, fn) {
           called = true;
           assert.equal(name, 'ack');
-          ackMessage.value = message.ack;
-          fn(ackMessage);
+          ackMessage.op = 'ack';
+          ackMessage.value = request.getAttr('ack');
+          var response = new Response(ackMessage);
+          fn(response);
         };
 
-        client._write(message, callback);
+        client._write(request, callback);
         assert.ok(called);
         assert.ok(passed);
       },
@@ -601,17 +636,18 @@ exports.RadarClient = {
       'should register an ack event handler that does not call the callback function for ack messages with a different value': function() {
         var called = false,
             passed = true,
-            message = { op: 'something', to: 'wherever:/account/scope/1' },
-            ackMessage = { value: -2 },
+            request = Request.buildSubscribe('status:/account/scope/1'),
+            ackMessage = { op: 'ack', value: -2 },
+            response = new Response(ackMessage),
             callback = function(msg) { passed = false; };
 
         client.when = function(name, fn) {
           called = true;
           assert.equal(name, 'ack');
-          fn(message);
+          fn(response);
         };
 
-        client._write(message, callback);
+        client._write(request, callback);
         assert.ok(called);
         assert.ok(passed);
       }
@@ -619,20 +655,43 @@ exports.RadarClient = {
 
     '._batch': {
       'should ignore messages without the appropriate properties': {
+        'op': function() {
+          var message = { to: 'status:/dev/ticket/1', value: 'x', time: new Date() / 1000 },
+              response;
+          
+          assert.throws(function ()
+            { response = new Response(message); },
+            /missing op/
+          );
+          assert.deepEqual(client._channelSyncTimes, {});
+        },
+
         'to': function() {
-          assert.ok(!client._batch({ value: 'x', time: new Date() / 1000 }));
+          var message = { op: 'subscribe', value: 'x', time: new Date() / 1000 },
+              response;
+          
+          assert.throws(function ()
+            { response = new Response(message); },
+            /missing to/
+          );
           assert.deepEqual(client._channelSyncTimes, {});
         },
 
         'value': function() {
+          var message = { op: 'subscribe', to: 'you', value: 'x'},
+              response = new Response(message);
+
           assert.equal(client._channelSyncTimes.you, undefined);
-          assert.ok(!client._batch({ value: 'x', to: 'you' }));
+          assert.ok(!client._batch(response));
           assert.equal(client._channelSyncTimes.you, undefined);
         },
 
         'time': function() {
+          var message = { op: 'subscribe', to: 'you', value: 'x' },
+              response = new Response(message);
+
           assert.equal(client._channelSyncTimes.you, undefined);
-          assert.ok(!client._batch({ value: 'x', to: 'you' }));
+          assert.ok(!client._batch(response));
           assert.equal(client._channelSyncTimes.you, undefined);
         }
       },
@@ -640,13 +699,15 @@ exports.RadarClient = {
       'should not ignore messages that have all the appropriate properties': function() {
         var now = new Date(),
             message = {
+              op: 'subscribe',
               to: 'you',
               value: [ '{}', now ],
               time: now
-            };
+            },
+            response = new Response(message);
 
         assert.equal(client._channelSyncTimes.you, undefined);
-        assert.notEqual(client._batch(message), false);
+        assert.notEqual(client._batch(response), false);
         assert.equal(client._channelSyncTimes.you, now);
       },
 
@@ -654,20 +715,22 @@ exports.RadarClient = {
         var called = false,
             now = new Date(),
             message = {
+              op: 'subscribe',
               to: 'you',
               value: [ '{ "something": 1 }', now ],
               time: now
-            };
+            },
+            response = new Response(message);
 
         client._channelSyncTimes.you = now - HOUR;
 
         client.emitNext = function(name, data) {
           called = true;
-          assert.equal(name, message.to);
-          assert.deepEqual(data, JSON.parse(message.value[0]));
+          assert.equal(name, response.getAttr('to'));
+          assert.deepEqual(data, JSON.parse(response.getAttr('value')[0]));
         };
 
-        assert.notEqual(client._batch(message), false);
+        assert.notEqual(client._batch(response), false);
         assert.equal(client._channelSyncTimes.you, now);
         assert.ok(called);
       }
@@ -866,7 +929,7 @@ exports.RadarClient = {
     '._sendMessage': {
       'should call sendPacket() on the _socket if the manager is activated': function() {
         var called = false,
-            message = { test: 1 };
+            request = Request.buildSubscribe('status:/test/ticket/1');
 
         client.manager.is = function(state) { return state == 'activated'; };
 
@@ -874,27 +937,27 @@ exports.RadarClient = {
           sendPacket: function(name, data) {
             called = true;
             assert.equal(name, 'message');
-            assert.equal(data, JSON.stringify(message));
+            assert.equal(data, JSON.stringify(request.getMessage()));
           }
         };
 
-        client._sendMessage(message);
+        client._sendMessage(request);
         assert.ok(called);
       },
 
       'should queue the message if the client has been configured, but is not activated': function() {
-        var message = { test: 1 };
+        var request = Request.buildSet('status:/test/ticket/1', 'any_value');
 
         client.configure({});
-        client._sendMessage(message);
-        assert.deepEqual(message, client._queuedMessages[0]);
+        client._sendMessage(request);
+        assert.deepEqual(request, client._queuedMessages[0]);
       },
 
       'should ignore the message if the client has not been configured': function() {
-        var message = { test: 1 };
+        var request = Request.buildSet('status:/test/ticket/1', 'any_value');
 
         assert.ok(!client._isConfigured);
-        client._sendMessage(message);
+        client._sendMessage(request);
         assert.equal(client._queuedMessages.length, 0);
       }
     },
@@ -912,7 +975,7 @@ exports.RadarClient = {
             if (name === 'message:in') return;
             called = true;
             assert.equal(name, message.op);
-            assert.deepEqual(data, message);
+            assert.deepEqual(data.message, message);
           };
 
           client._messageReceived(json);
@@ -923,6 +986,7 @@ exports.RadarClient = {
           var called = false,
               message = {
                 op: 'ack',
+                value: 1
               },
               json = JSON.stringify(message);
 
@@ -930,7 +994,7 @@ exports.RadarClient = {
             if (name === 'message:in') return;
             called = true;
             assert.equal(name, message.op);
-            assert.deepEqual(data, message);
+            assert.deepEqual(data.message, message);
           };
 
           client._messageReceived(json);
@@ -941,6 +1005,7 @@ exports.RadarClient = {
           var called = false,
               message = {
                 op: 'get',
+                to: 'staus:/test/ticket/1'
               },
               json = JSON.stringify(message);
 
@@ -948,7 +1013,7 @@ exports.RadarClient = {
             if (name === 'message:in') return;
             called = true;
             assert.equal(name, message.op);
-            assert.deepEqual(data, message);
+            assert.deepEqual(data.message, message);
           };
 
           client._messageReceived(json);
@@ -959,12 +1024,13 @@ exports.RadarClient = {
           var called = false,
               message = {
                 op: 'sync',
+                to: 'staus:/test/ticket/1'
               },
               json = JSON.stringify(message);
 
           client._batch = function(msg) {
             called = true;
-            assert.deepEqual(msg, message);
+            assert.deepEqual(msg.message, message);
           };
 
           client._messageReceived(json);


### PR DESCRIPTION
Second version of the message library, used by radar_client. Refactor lib/radar_client.js to write separate, explicit get and sync functions. Identify request (aka client) and response (aka server) messages, and associated message lib API calls (now with some  server response messages.)

The PRs https://github.com/zendesk/radar_client/pull/51 and https://github.com/zendesk/radar_client/pull/52 are now closed. This implementation is the same as that in PR https://github.com/zendesk/radar_client/pull/52, with this *sole difference* - it is committed to a branch off the feature branch *pobrien/feature_message_protocol_v2*.  The feature branch will later be merged to master.

The majority of this code manipulates request/response objects, and not raw messages.  Raw messages still exist in the public APIs (cannot change these), callbacks, and messages handlers from radar server.  Tests have been modified to use request/response where needed.

Known limitations: zendesk_radar_client and its tests access some radar_client properties directly, and so some tests there are currently breaking.

/cc @zendesk/zendesk-radar

### Steps to merge
 - [ ] :+1: of the team

### References
 - Jira link:  https://zendesk.atlassian.net/browse/RADAR-481

### Risks
 - Medium to High: all existing client messages are now provided by the library, so a lot of logic has changed.