### PR TITLE
Refactor the 'init' method to separate 'sync' and 'get' methods

### DIFF
--- a/lib/radar_client.js
+++ b/lib/radar_client.js
@@ -195,62 +195,80 @@ Client.prototype.unsubscribe = function(scope, callback) {
   return this._write({ op: 'unsubscribe', to: scope }, callback);
 };
 
-// Sync and get return the actual value of the operation
-var init = function(propertyName) {
-  Client.prototype[propertyName] = function(scope, options, callback) {
-    var message = { op: propertyName, to: scope };
-    // options is an optional argument
-    if (typeof options == 'function') {
-      callback = options;
-    } else {
-      message.options = options;
+var v2ResponseToV1 = function (message) {
+  // Translate v2 response to v1
+  var value = {}, userId;
+  for (userId in message.value) {
+    if (message.value.hasOwnProperty(userId)) {
+      // Skip when not defined; causes exception in FF for 'Work Offline'
+      if (!message.value[userId]) { continue; }
+      value[userId] = message.value[userId].userType;
     }
-    // Sync v1 for presence scopes acts inconsistently. The result should be a
-    // "get" message, but it is actually a "online" message.
-    // So force v2 and translate the result to v1 format.
-    if (propertyName == 'sync' && !message.options && scope.match(/^presence.+/)) {
-      message.options = { version: 2 };
-      this.when('get', function(message) {
-        var value = {}, userId;
-        if (!message || !message.to || message.to != scope) {
-          return false;
-        }
+  }
+  message.value = value;
+  message.op = 'online';
 
-        for (userId in message.value) {
-          if (message.value.hasOwnProperty(userId)) {
-            // Skip when not defined; causes exception in FF for 'Work Offline'
-            if (!message.value[userId]) { continue; }
-            value[userId] = message.value[userId].userType;
-          }
-        }
-        message.value = value;
-        message.op = 'online';
-        if (callback) {
-          callback(message);
-        }
-        return true;
-      });
-    } else {
-      this.when('get', function(message) {
-        if (!message || !message.to || message.to != scope) {
-          return false;
-        }
-        if (callback) {
-          callback(message);
-        }
-        return true;
-      });
-    }
-    // sync/get never register or return acks (since they always send back a
-    // data message)
-    return this._write(message);
-  };
+  return message;
 };
 
-var props = ['get', 'sync'];
-for(var i = 0; i < props.length; i++){
-  init(props[i]);
-}
+Client.prototype.sync = function (scope, options, callback) {
+  var message = { op: 'sync', to: scope };
+  // options is an optional argument
+  if (typeof options == 'function') {
+    callback = options;
+  } else {
+    message.options = options;
+  }
+  // So force v2 and translate the result to v1 format.
+  var v1Presence = !message.options && scope.match(/^presence.+/);
+  var onResponse = function (message) {
+    if (message && message.to && message.to === scope) {
+      if (v1Presence) {
+        message = v2ResponseToV1(message);
+      }
+
+      if (callback) {
+        callback(message);
+      }
+      return true;
+    }
+    return false;
+  };
+
+  if (v1Presence) {
+    message.options = { version: 2 };
+  }
+
+  this.when('get', onResponse);
+
+  // sync/get never register or return acks (since they always send back a
+  // data message)
+  return this._write(message);
+};
+
+Client.prototype.get = function (scope, options, callback) {
+  var message = { op: 'get', to: scope };
+  // options is an optional argument
+  if (typeof options == 'function') {
+    callback = options;
+  } else {
+    message.options = options;
+  }
+
+  this.when('get', function(message) {
+    if (!message || !message.to || message.to != scope) {
+      return false;
+    }
+    if (callback) {
+      callback(message);
+    }
+    return true;
+  });
+
+  // sync/get never register or return acks (since they always send back a
+  // data message)
+  return this._write(message);
+};
 
 // Private API
 


### PR DESCRIPTION
Small (but tricky) refactor described in the PR title.

/cc @zendesk/zendesk-radar

### Steps to merge
 - [ ] :+1: of the team

### References
 - Jira link: 

### Risks
 - None