### PR TITLE
Remove build of dist prior to test

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
     "check-modules": "if [ -z \"$SKIP_PACKAGE_CHECK\" ] && [ ./package.json -nt ./node_modules ]; then npm run warn-outdated && exit 1; else rm -rf ./node_modules/sfsm/demo; fi",
     "warn-outdated": "echo 'Your node_modules are out of date. Please run \"rm -rf node_modules && npm install\" in order to ensure you have the latest dependencies.'",
     "warn-dirty-tree": "echo 'Your repo tree is dirty.'",
-    "pretest": "npm run build",
     "test": "ls ./tests/*.test.js | xargs -n 1 -t -I {} sh -c 'TEST=\"{}\" npm run test-one'",
     "test-one": "./node_modules/.bin/mocha --ui exports --reporter spec --slow 2000ms --bail \"$TEST\"",
     "test-one-solo": "./node_modules/.bin/mocha --ui exports --reporter spec --slow 2000ms --bail",

--- a/package.json
+++ b/package.json
@@ -50,6 +50,8 @@
     "test-one-solo": "./node_modules/.bin/mocha --ui exports --reporter spec --slow 2000ms --bail",
     "prebuild": "npm run check-modules",
     "build": "npm run version-build; ./node_modules/gluejs/bin/gluejs --include ./lib --npm microee,sfsm --replace engine.io-client=eio,minilog=Minilog --global RadarClient --main lib/index.js --out dist/radar_client.js",
-    "version-build": "node scripts/add_client_version.js"
+    "version-build": "node scripts/add_client_version.js",
+    "prepublish": "npm run build; if [ $(git diff --name-status dist/radar_client.js | wc -l) -ne  \"0\" ]; then npm run warn-dist-check-in && exit 1; fi",
+    "warn-dist-check-in": "echo 'dist file needs to be checked in before publishing to NPM.'"
   }
 }


### PR DESCRIPTION
Don't build dist/ files in the course of PRs, or when running tests.  Build dist/ files only when needed, prior to release.

/cc @zendesk/zendesk-radar

### Steps to merge
 - [ ] :+1: of the team

### References
 - Jira link: https://zendesk.atlassian.net/browse/RADAR-566

### Risks
 - None