### PR TITLE
Update Changelog and add .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+dist/* -diff

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,11 @@
+### 0.15.0
+* Use radar message library
+  - significant refactor that changes most of the code underlying the public
+    APIs, which have *not* been changed
+  - explicitly extracted the message "library" code in the refactor above to a
+    separate radar_message library
+  - pin radar_message version (we'll specify versions of package moving forward)
+
 ### 0.14.5
 * Presence resource can set online and include client data (to be broadcasted
   as part of the client_online and client_updated events). 


### PR DESCRIPTION
Update the Changelog to record the addition of the radar_message library (see https://github.com/zendesk/radar_client/pull/58).  Add .gitattributes file and entry to ignore dist/ diffs on PRs

/cc @zendesk/zendesk-radar

### Steps to merge
 - [ ] :+1: of the team

### References
 - Jira link: https://zendesk.atlassian.net/browse/RADAR-566

### Risks
 - None