### PR TITLE
fix: send nameSync only once per session

### DIFF
--- a/lib/radar_client.js
+++ b/lib/radar_client.js
@@ -16,6 +16,7 @@ function Client(backend) {
   this._presences = {};
   this._subscriptions = {};
   this._restoreRequired = false;
+  this._identitySetRequired = true;
   this._queuedMessages = [];
   this._isConfigured = false;
 
@@ -396,6 +397,7 @@ Client.prototype._createManager = function() {
 
   manager.on('disconnect', function() {
     self._restoreRequired = true;
+    self._identitySetRequired = true;
   });
 };
 
@@ -462,6 +464,7 @@ Client.prototype._sendMessage = function(message) {
     this._socket.sendPacket('message', JSON.stringify(message));
   } else if (this._isConfigured) {
     this._restoreRequired = true;
+    this._identitySetRequired = true;
     if (!memorized || message.ack) {
       this._queuedMessages.push(message);
     }
@@ -492,16 +495,20 @@ Client.prototype.emitNext = function() {
 };
 
 Client.prototype._identitySet = function () {
-  if (!this.name) {
-    this.name = this._uuidV4Generate();
+  if (this._identitySetRequired) {
+    this._identitySetRequired = false;
+
+    if (!this.name) {
+      this.name = this._uuidV4Generate();
+    }
+
+    // Send msg that associates this.id with current name
+    var association = { id : this._socket.id, name: this.name };
+    var clientVersion = getClientVersion();
+    var options = { association: association, clientVersion: clientVersion };
+
+    this.control('clientName').nameSync(options);
   }
-
-  // Send msg that associates this.id with current name
-  var association = { id : this._socket.id, name: this.name };
-  var clientVersion = getClientVersion();
-  var options = { association: association, clientVersion: clientVersion };
-
-  this.control('clientName').nameSync(options);
 }; 
 
 // Variant (by Jeff Ward) of code behind node-uuid, but avoids need for module


### PR DESCRIPTION
This PR is informational only, to show @lucasefe the changes that are needed so that *nameSync* is issued only once per session.  These changes are against the tag f970e90.

/cc @lucasefe 

### Steps to merge
 - [ ] :+1: of the team

### References
 - Jira link: 

### Risks
 - None