### PR TITLE
fix: send nameSync only once per session

### DIFF
--- a/lib/radar_client.js
+++ b/lib/radar_client.js
@@ -19,6 +19,7 @@ function Client(backend) {
   this._subscriptions = {};
   this._restoreRequired = false;
   this._queuedRequests = [];
+  this._identitySetRequired = true;
   this._isConfigured = false;
 
   this._createManager();
@@ -376,6 +377,7 @@ Client.prototype._createManager = function() {
 
   manager.on('disconnect', function() {
     self._restoreRequired = true;
+    self._identitySetRequired = true;
   });
 };
 
@@ -451,6 +453,7 @@ Client.prototype._sendMessage = function(request) {
     this._socket.sendPacket('message', request.payload());
   } else if (this._isConfigured) {
     this._restoreRequired = true;
+    this._identitySetRequired = true;
     if (!memorized || ack) {
       this._queuedRequests.push(request);
     }
@@ -487,19 +490,23 @@ Client.prototype.emitNext = function() {
 };
 
 Client.prototype._identitySet = function () {
-  if (!this.name) {
-    this.name = this._uuidV4Generate();
+  if (this._identitySetRequired) {
+    this._identitySetRequired = false;
+
+    if (!this.name) {
+      this.name = this._uuidV4Generate();
+    }
+
+    // Send msg that associates this.id with current name
+    var association = { id : this._socket.id, name: this.name };
+    var clientVersion = getClientVersion();
+    var options = { association: association, clientVersion: clientVersion };
+    var self = this;
+
+    this.control('clientName').nameSync(options, function (message) {
+      self.logger('nameSync message: ' + JSON.stringify(message));
+    });
   }
-
-  // Send msg that associates this.id with current name
-  var association = { id : this._socket.id, name: this.name };
-  var clientVersion = getClientVersion();
-  var options = { association: association, clientVersion: clientVersion };
-  var self = this;
-
-  this.control('clientName').nameSync(options, function (message) {
-    self.logger('nameSync message: ' + JSON.stringify(message));
-  });
 }; 
 
 // Variant (by Jeff Ward) of code behind node-uuid, but avoids need for module


### PR DESCRIPTION
Cherry pick changes from https://github.com/zendesk/radar_client/pull/61/commits and apply them on master. 

### Steps to merge
 - [ ] :+1: of the @zendesk/radar team

### Risks
 - None
