### PR TITLE
fake test timers with sinon.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,9 @@
   },
   "devDependencies": {
     "gluejs": "2.3.9",
-    "mocha": "*"
+    "jshint": "^2.8.0",
+    "mocha": "^2.3.3",
+    "sinon": "^1.17.1"
   },
   "scripts": {
     "check-clean": "if [[ $(git diff --shortstat 2> /dev/null | tail -n1) != \"\" ]]; then npm run warn-dirty-tree && exit 1; fi",

--- a/tests/state.test.js
+++ b/tests/state.test.js
@@ -1,11 +1,18 @@
 var assert = require('assert'),
     log = require('minilog')('state.test'),
     StateMachine = require('../lib/state.js'),
-    machine;
+    machine,
+    sinon = require('sinon'),
+    clock;
 
 exports['given a state machine'] = {
   beforeEach: function() {
     machine = StateMachine.create();
+    clock = sinon.useFakeTimers();
+  },
+
+  afterEach: function() {
+    clock.restore();
   },
 
   'calling start twice should not cause two connections': function(done) {
@@ -29,6 +36,7 @@ exports['given a state machine'] = {
 
   'if the user calls disconnect the machine will reconnect after a delay': function(done) {
     this.timeout(4000);
+
     machine.open();
     machine.connect();
     assert.ok(machine.is('connecting'));
@@ -37,6 +45,7 @@ exports['given a state machine'] = {
       done();
     });
     machine.disconnect();
+    clock.tick(2500);
   },
 
   'the first connection should begin connecting, after disconnected it should automatically reconnect': function(done) {
@@ -57,6 +66,7 @@ exports['given a state machine'] = {
     });
 
     machine.disconnect();
+    clock.tick(2500);
   },
 
   'connections that hang should be detected after 10 seconds': function(done) {
@@ -67,6 +77,7 @@ exports['given a state machine'] = {
     };
 
     machine.connect();
+    clock.tick(10001);
   },
 
   'should not get caught by timeout if connect fails for different reasons' : function(done) {
@@ -93,6 +104,8 @@ exports['given a state machine'] = {
       }
     });
     machine.connect();
+
+    clock.tick(15001);
   },
 
   'connections that fail should cause exponential backoff, finally emit unavailable': function(done) {
@@ -114,6 +127,8 @@ exports['given a state machine'] = {
     });
 
     machine.connect();
+
+    clock.tick(64000);
 
   },
 


### PR DESCRIPTION
Small improvement to test suite- same coverage but much faster runtimes by using [sinon](http://sinonjs.org/docs/#clock) to override the system clock for timeouts.

With this pr:
```
time npm test
...
real	0m10.404s
user	0m5.576s
sys	0m0.704s
```

Previously
```
real	1m41.499s
user	0m5.627s
sys	0m0.720s
```

Still not great, but much improved.

### Steps to merge
 - [ ] :+1: of the @zendesk/radar team

### Risks
 - None
