### PR TITLE
Fix license metadata in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,8 +2,10 @@
   "name": "radar_client",
   "description": "Realtime apps with a high level API based on engine.io",
   "version": "0.15.1",
-  "author": "Mikito Takada <mikito.takada@gmail.com>",
+  "license": "Apache-2.0",
+  "author": "Zendesk, Inc.",
   "contributors": [
+    "Mikito Takada <mikito.takada@gmail.com>",
     {
       "name": "Sam Shull",
       "url": "http://github.com/samshull"


### PR DESCRIPTION
- Adds correct [SPDX](https://docs.npmjs.com/files/package.json#license) code for Apache 2 license to package.json
- Updates author to Zendesk, Inc.


Required
========
- [ ] :+1: from @zendesk/radar

Risks
========
- None (no code change)