### PR TITLE
Loosen version range on radar_message dependency

### DIFF
--- a/dist/radar_client.js
+++ b/dist/radar_client.js
@@ -1076,7 +1076,7 @@ var RadarClient =
 
 	// Auto-generated file, overwritten by scripts/add_package_version.js
 
-	function getClientVersion () { return '0.15.1' }
+	function getClientVersion () { return '0.15.2' }
 
 	module.exports = getClientVersion
 

--- a/lib/client_version.js
+++ b/lib/client_version.js
@@ -1,5 +1,5 @@
 // Auto-generated file, overwritten by scripts/add_package_version.js
 
-function getClientVersion () { return '0.15.1' }
+function getClientVersion () { return '0.15.2' }
 
 module.exports = getClientVersion

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "minilog": "*",
     "engine.io-client": "1.4.2",
     "sfsm": "0.0.4",
-    "radar_message": "1.0.1"
+    "radar_message": "~1.0.1"
   },
   "devDependencies": {
     "gulp": "^3.9.1",


### PR DESCRIPTION
Allow any backwards-compatible version of 1.x

Required
========
- [ ] :+1: from @zendesk/radar

Risks
========
- Low: if we violate semver on radar_message, it could introduce a breaking change here.