### PR TITLE
Second try: flexible minor, patch specifier for radar_message dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "minilog": "*",
     "engine.io-client": "1.4.2",
     "sfsm": "0.0.4",
-    "radar_message": "~1.0.1"
+    "radar_message": "^1.0.1"
   },
   "devDependencies": {
     "gulp": "^3.9.1",


### PR DESCRIPTION
References
========
- https://github.com/zendesk/radar_client/pull/70

Required
========
- [ ] :+1: from @zendesk/radar

Risks
========
- None