### PR TITLE
adds a random splay to the backoff

### DIFF
--- a/dist/radar_client.js
+++ b/dist/radar_client.js
@@ -43,7 +43,7 @@ var RadarClient =
 /************************************************************************/
 /******/ ([
 /* 0 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ (function(module, exports, __webpack_require__) {
 
 	var Client = __webpack_require__(1)
 	var instance = new Client()
@@ -57,9 +57,9 @@ var RadarClient =
 	module.exports = instance
 
 
-/***/ },
+/***/ }),
 /* 1 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ (function(module, exports, __webpack_require__) {
 
 	/* globals setImmediate */
 	var MicroEE = __webpack_require__(2)
@@ -602,9 +602,9 @@ var RadarClient =
 	module.exports = Client
 
 
-/***/ },
+/***/ }),
 /* 2 */
-/***/ function(module, exports) {
+/***/ (function(module, exports) {
 
 	function M() { this._events = {}; }
 	M.prototype = {
@@ -623,6 +623,9 @@ var RadarClient =
 	  removeAllListeners: function(ev) {
 	    if(!ev) { this._events = {}; }
 	    else { this._events[ev] && (this._events[ev] = []); }
+	  },
+	  listeners: function(ev) {
+	    return (this._events ? this._events[ev] || [] : []);
 	  },
 	  emit: function(ev) {
 	    this._events || (this._events = {});
@@ -655,15 +658,15 @@ var RadarClient =
 	module.exports = M;
 
 
-/***/ },
+/***/ }),
 /* 3 */
-/***/ function(module, exports) {
+/***/ (function(module, exports) {
 
 	module.exports = eio;
 
-/***/ },
+/***/ }),
 /* 4 */
-/***/ function(module, exports) {
+/***/ (function(module, exports) {
 
 	function Scope (typeName, scope, client) {
 	  this.client = client
@@ -693,9 +696,9 @@ var RadarClient =
 	module.exports = Scope
 
 
-/***/ },
+/***/ }),
 /* 5 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ (function(module, exports, __webpack_require__) {
 
 	var log = __webpack_require__(6)('radar_state')
 	var MicroEE = __webpack_require__(2)
@@ -725,17 +728,13 @@ var RadarClient =
 
 	    callbacks: {
 	      onevent: function (event, from, to) {
-	        log.debug('before-' + event + ', from: ' + from + ', to: ' + to,
-	          Array.prototype.slice.call(arguments))
+	        log.debug('from ' + from + ' -> ' + to + ', event: ' + event)
 
 	        this.emit('event', event)
 	        this.emit(event, arguments)
 	      },
 
 	      onstate: function (event, from, to) {
-	        log.debug('event-state-' + event + ', from: ' + from + ', to: ' + to,
-	          Array.prototype.slice.call(arguments))
-
 	        this.emit('enterState', to)
 	        this.emit(to, arguments)
 	      },
@@ -755,15 +754,17 @@ var RadarClient =
 	      },
 
 	      ondisconnected: function (event, from, to) {
-	        backoff.increment()
-
 	        if (this._timer) {
 	          clearTimeout(this._timer)
 	          delete this._timer
 	        }
 
 	        var time = backoff.get()
+	        backoff.increment()
+
+	        this.emit('backoff', time, backoff.failures)
 	        log.debug('reconnecting in ' + time + 'msec')
+
 	        this._timer = setTimeout(function () {
 	          delete machine._timer
 	          if (machine.is('disconnected')) {
@@ -836,15 +837,15 @@ var RadarClient =
 	module.exports = { create: create }
 
 
-/***/ },
+/***/ }),
 /* 6 */
-/***/ function(module, exports) {
+/***/ (function(module, exports) {
 
 	module.exports = Minilog;
 
-/***/ },
+/***/ }),
 /* 7 */
-/***/ function(module, exports) {
+/***/ (function(module, exports) {
 
 	function Backoff () {
 	  this.failures = 0
@@ -852,9 +853,11 @@ var RadarClient =
 
 	Backoff.durations = [1000, 2000, 4000, 8000, 16000, 32000] // seconds (ticks)
 	Backoff.fallback = 60000
+	Backoff.maxSplay = 5000
 
 	Backoff.prototype.get = function () {
-	  return Backoff.durations[this.failures] || Backoff.fallback
+	  var splay = Math.ceil(Math.random() * Backoff.maxSplay)
+	  return splay + (Backoff.durations[this.failures] || Backoff.fallback)
 	}
 
 	Backoff.prototype.increment = function () {
@@ -872,9 +875,9 @@ var RadarClient =
 	module.exports = Backoff
 
 
-/***/ },
+/***/ }),
 /* 8 */
-/***/ function(module, exports) {
+/***/ (function(module, exports) {
 
 	/*
 
@@ -1067,9 +1070,9 @@ var RadarClient =
 	  }; // StateMachine
 
 
-/***/ },
+/***/ }),
 /* 9 */
-/***/ function(module, exports) {
+/***/ (function(module, exports) {
 
 	// Auto-generated file, overwritten by scripts/add_package_version.js
 
@@ -1078,9 +1081,9 @@ var RadarClient =
 	module.exports = getClientVersion
 
 
-/***/ },
+/***/ }),
 /* 10 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ (function(module, exports, __webpack_require__) {
 
 	var Request = __webpack_require__(11),
 	    Response = __webpack_require__(12),
@@ -1094,9 +1097,9 @@ var RadarClient =
 	module.exports = RadarMessage;
 
 
-/***/ },
+/***/ }),
 /* 11 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ (function(module, exports, __webpack_require__) {
 
 	var logger = __webpack_require__(6)('message:request');
 
@@ -1276,9 +1279,9 @@ var RadarClient =
 	module.exports = Request;
 
 
-/***/ },
+/***/ }),
 /* 12 */
-/***/ function(module, exports, __webpack_require__) {
+/***/ (function(module, exports, __webpack_require__) {
 
 	var logger = __webpack_require__(6)('message:response');
 
@@ -1358,9 +1361,9 @@ var RadarClient =
 	module.exports = Response;
 
 
-/***/ },
+/***/ }),
 /* 13 */
-/***/ function(module, exports) {
+/***/ (function(module, exports) {
 
 	function Batch () {
 		var messages = Array.prototype.slice.call(arguments)
@@ -1390,5 +1393,5 @@ var RadarClient =
 	module.exports = Batch
 
 
-/***/ }
+/***/ })
 /******/ ]);

--- a/dist/radar_client.js
+++ b/dist/radar_client.js
@@ -446,6 +446,10 @@ var RadarClient =
 	    self._restoreRequired = true
 	    self._identitySetRequired = true
 	  })
+
+	  manager.on('backoff', function (time, step) {
+	    self.emit('backoff', time, step)
+	  })
 	}
 
 	// Memorize subscriptions and presence states; return "true" for a message that

--- a/lib/backoff.js
+++ b/lib/backoff.js
@@ -4,9 +4,11 @@ function Backoff () {
 
 Backoff.durations = [1000, 2000, 4000, 8000, 16000, 32000] // seconds (ticks)
 Backoff.fallback = 60000
+Backoff.maxSplay = 5000
 
 Backoff.prototype.get = function () {
-  return Backoff.durations[this.failures] || Backoff.fallback
+  var splay = Math.ceil(Math.random() * Backoff.maxSplay)
+  return splay + (Backoff.durations[this.failures] || Backoff.fallback)
 }
 
 Backoff.prototype.increment = function () {

--- a/lib/radar_client.js
+++ b/lib/radar_client.js
@@ -383,6 +383,10 @@ Client.prototype._createManager = function () {
     self._restoreRequired = true
     self._identitySetRequired = true
   })
+
+  manager.on('backoff', function(time, step) {
+    self.emit('backoff', time, step)
+  })
 }
 
 // Memorize subscriptions and presence states; return "true" for a message that

--- a/lib/radar_client.js
+++ b/lib/radar_client.js
@@ -384,7 +384,7 @@ Client.prototype._createManager = function () {
     self._identitySetRequired = true
   })
 
-  manager.on('backoff', function(time, step) {
+  manager.on('backoff', function (time, step) {
     self.emit('backoff', time, step)
   })
 }

--- a/lib/state.js
+++ b/lib/state.js
@@ -26,17 +26,13 @@ function create () {
 
     callbacks: {
       onevent: function (event, from, to) {
-        log.debug('before-' + event + ', from: ' + from + ', to: ' + to,
-          Array.prototype.slice.call(arguments))
+        log.debug('from ' + from + ' -> ' + to + ', event: ' + event)
 
         this.emit('event', event)
         this.emit(event, arguments)
       },
 
       onstate: function (event, from, to) {
-        log.debug('event-state-' + event + ', from: ' + from + ', to: ' + to,
-          Array.prototype.slice.call(arguments))
-
         this.emit('enterState', to)
         this.emit(to, arguments)
       },
@@ -56,15 +52,17 @@ function create () {
       },
 
       ondisconnected: function (event, from, to) {
-        backoff.increment()
-
         if (this._timer) {
           clearTimeout(this._timer)
           delete this._timer
         }
 
         var time = backoff.get()
+        backoff.increment()
+
+        this.emit('backoff', time, backoff.failures)
         log.debug('reconnecting in ' + time + 'msec')
+
         this._timer = setTimeout(function () {
           delete machine._timer
           if (machine.is('disconnected')) {

--- a/tests/backoff.test.js
+++ b/tests/backoff.test.js
@@ -20,7 +20,9 @@ exports['given a backoff'] = {
   'durations increase as failures increase': function (done) {
     var b = this.b
     Backoff.durations.forEach(function (duration) {
-      assert.equal(duration, b.get())
+      var v = b.get()
+      assert(duration <= v)
+      assert(duration + Backoff.maxSplay > v)
       b.increment()
     })
     done()
@@ -28,11 +30,12 @@ exports['given a backoff'] = {
 
   'successful connection resets durations so that a random error doesnt cause a long wait': function (done) {
     var b = this.b
-    assert.equal(b.get(), 1000)
+    assert(b.get() >= 1000)
     b.increment()
-    assert.ok(b.get() > 1000)
+    assert(b.get() >= 2000)
     b.success()
-    assert.equal(b.get(), 1000)
+    var v = b.get()
+    assert(v >= 1000 && v < 6000)
     done()
   },
 
@@ -45,7 +48,7 @@ exports['given a backoff'] = {
     b.increment()
     b.increment()
     b.increment()
-    assert.equal(b.get(), 60000)
+    assert(b.get() > 60000)
     done()
   }
 

--- a/tests/radar_client.events.test.js
+++ b/tests/radar_client.events.test.js
@@ -51,8 +51,14 @@ exports['given a new presence'] = {
     setTimeout(function () {
       done()
     }, 10)
-  }
+  },
 
+  'forwards backoff events from manager': function(done) {
+    this.client.once('backoff', function(time, step) {
+      done()
+    })
+    this.client.manager.emit('backoff', 10, 1)
+  }
 }
 
 // When this module is the script being run, run the tests:

--- a/tests/radar_client.events.test.js
+++ b/tests/radar_client.events.test.js
@@ -53,8 +53,8 @@ exports['given a new presence'] = {
     }, 10)
   },
 
-  'forwards backoff events from manager': function(done) {
-    this.client.once('backoff', function(time, step) {
+  'forwards backoff events from manager': function (done) {
+    this.client.once('backoff', function (time, step) {
       done()
     })
     this.client.manager.emit('backoff', 10, 1)

--- a/tests/radar_client.test.js
+++ b/tests/radar_client.test.js
@@ -2,10 +2,14 @@ var assert = require('assert')
 var RadarClient = require('../lib/radar_client.js')
 var MockEngine = require('./lib/engine.js')
 var Response = require('radar_message').Response
+var Backoff = require('../lib/backoff.js')
 var client
 
 exports['before connecting'] = {
   before: function (done) {
+    // speed up some tests
+    Backoff.maxSplay = 100
+    Backoff.durations = [ 100, 200, 400 ]
     RadarClient.setBackend(MockEngine)
     done()
   },
@@ -104,7 +108,6 @@ exports['after reconnecting'] = {
   },
 
   'should resend queued presences': function (done) {
-    this.timeout(4000)
     var connected = false
 
     client.presence('tickets/21').set('online')
@@ -133,7 +136,6 @@ exports['after reconnecting'] = {
   },
 
   'should resend queued subscriptions': function (done) {
-    this.timeout(4000)
     var connected = false
 
     client.presence('tickets/21').subscribe()


### PR DESCRIPTION
This prevents thundering herds and spreads reconnections
over the maxSplay provided (5 secs)
Adds a backoff event with time and number of failures until now.

Also fixes a bug where we always ignore the first backoff duration

@prudhvi 