### PR TITLE
Fix late socket open

### DIFF
--- a/lib/radar_client.js
+++ b/lib/radar_client.js
@@ -382,6 +382,22 @@ Client.prototype._createManager = function () {
   manager.on('disconnect', function () {
     self._restoreRequired = true
     self._identitySetRequired = true
+
+    var socket = self._socket
+    if (socket) {
+      // If you reach disconnect with a socket obj,
+      // it might be from startGuard (open timeout reached)
+      // Clear out the current attempt to get a socket
+      // and close it if it opens
+      socket.removeAllListeners('message')
+      socket.removeAllListeners('open')
+      socket.removeAllListeners('close')
+      socket.once('open', function () {
+        self.logger().debug('socket open, closing it', socket.id)
+        socket.close()
+      })
+      self._socket = null
+    }
   })
 
   manager.on('backoff', function (time, step) {

--- a/tests/lib/engine.js
+++ b/tests/lib/engine.js
@@ -28,17 +28,22 @@ Socket.prototype.close = function () {
 
 var current = new Socket()
 
-function wrap () {
+function wrap (delay) {
   current.removeAllListeners()
   current._opened = false
   setTimeout(function () {
     current.emit('open')
     current._opened = true
-  }, 5)
+  }, delay)
   return current
 }
 
-module.exports = {
-  Socket: wrap,
-  current: current
+var MockEngine = function (openDelay) {
+  openDelay = openDelay || 5
+  return {
+    Socket: function () { return wrap(openDelay) },
+    current: current
+  }
 }
+
+module.exports = MockEngine

--- a/tests/radar_client.alloc.test.js
+++ b/tests/radar_client.alloc.test.js
@@ -1,5 +1,5 @@
 var assert = require('assert')
-var MockEngine = require('./lib/engine.js')
+var MockEngine = require('./lib/engine.js')()
 var RadarClient = require('../lib/radar_client.js')
 var getClientVersion = require('../lib/client_version.js')
 var client

--- a/tests/radar_client.connect.test.js
+++ b/tests/radar_client.connect.test.js
@@ -1,0 +1,64 @@
+var assert = require('assert')
+var RadarClient = require('../lib/radar_client.js')
+// With a delay
+var MockEngine = require('./lib/engine.js')(150)
+var Backoff = require('../lib/backoff.js')
+var Minilog = require('minilog')
+var client
+
+if (process.env.verbose === '1') {
+  Minilog.pipe(Minilog.backends.nodeConsole.formatWithStack).pipe(Minilog.backends.nodeConsole)
+}
+
+exports['before connecting'] = {
+  before: function (done) {
+    // make sure the first backoff will leave enough time
+    Backoff.maxSplay = 100
+    Backoff.durations = [ 200, 300, 400 ]
+    RadarClient.setBackend(MockEngine)
+    done()
+  },
+  after: function (done) {
+    RadarClient.setBackend({})
+    done()
+  },
+
+  beforeEach: function (done) {
+    client = new RadarClient()
+    client.configure({ accountName: 'test', userId: 123, userType: 2 })
+    client.alloc('channel', done)
+  },
+
+  afterEach: function (done) {
+    MockEngine.current._written = []
+    done()
+  },
+
+  'socket opening late should not cause two open sockets': function (done) {
+    // set wait time to 10, while it takes 150ms for a socket to open
+    client.manager._connectTimeout = 10
+    client.on('backoff', function (time, failures) {
+      // second backoff: after first failure, we expand open timeout
+      // to be > 150
+      // This is the same as shrinking the socket open delay
+      if (failures === 2) {
+        client.manager._connectTimeout = 300
+      }
+    })
+    client._socket.close()
+    client.on('ready', function () {
+      // Wait for 150 so any pending sockets can open
+      setTimeout(function () {
+        var openSockets = 0
+        for (var i = 0; i < MockEngine.sockets.length; i++) {
+          if (MockEngine.sockets[i]._state === 'open' || MockEngine.sockets[i]._state === 'opening') {
+            openSockets++
+          }
+        }
+
+        assert.equal(openSockets, 1)
+        done()
+      }, 150)
+    })
+  }
+}

--- a/tests/radar_client.test.js
+++ b/tests/radar_client.test.js
@@ -1,6 +1,6 @@
 var assert = require('assert')
 var RadarClient = require('../lib/radar_client.js')
-var MockEngine = require('./lib/engine.js')
+var MockEngine = require('./lib/engine.js')()
 var Response = require('radar_message').Response
 var Backoff = require('../lib/backoff.js')
 var client

--- a/tests/radar_client.unit.test.js
+++ b/tests/radar_client.unit.test.js
@@ -1,6 +1,6 @@
 var assert = require('assert')
 var RadarClient = require('../lib/radar_client.js')
-var MockEngine = require('./lib/engine.js')
+var MockEngine = require('./lib/engine.js')()
 var Request = require('radar_message').Request
 var Response = require('radar_message').Response
 var HOUR = 1000 * 60 * 60

--- a/tests/state.test.js
+++ b/tests/state.test.js
@@ -83,7 +83,7 @@ exports['given a state machine'] = {
     clock.tick(machine._connectTimeout + 1)
   },
 
-  'should not get caught by timeout if connect fails for different reasons': function (done) {
+  'should not get caught by timeout if connect takes too long': function (done) {
     var once = true
     var disconnects = 0
 


### PR DESCRIPTION
When a socket opens late, (more than manager._connectTimeout), it leads to two open sockets. Here's a failing test to simulate this. Followed by the fix.

@zendesk/radar 

```
-$ verbose=1 mocha tests/radar_client.connect.test.js


  before connecting
radar_state debug /Users/vanchi/harmony/code/radar_client/lib/state.js:29 from none -> opened, event: open
radar_client /Users/vanchi/harmony/code/radar_client/lib/radar_client.js:41
radar_client  info /Users/vanchi/harmony/code/radar_client/lib/radar_client.js:41 alloc:  channel
radar_state debug /Users/vanchi/harmony/code/radar_client/lib/state.js:29 from opened -> connecting, event: connect
radar_client /Users/vanchi/harmony/code/radar_client/lib/radar_client.js:339
radar_client debug /Users/vanchi/harmony/code/radar_client/lib/radar_client.js:339 socket open
radar_state debug /Users/vanchi/harmony/code/radar_client/lib/state.js:29 from connected -> authenticating, event: authenticate
radar_state debug /Users/vanchi/harmony/code/radar_client/lib/state.js:29 from authenticating -> activated, event: activate
test /Users/vanchi/harmony/code/radar_client/tests/lib/engine.js:22 {"op":"nameSync","to":"control:/test/clientName","options":{"association":{"name":"b9538713-b33b-4358-8eec-8946d3633cdd"},"clientVersion":"0.16.0"},"ack":1}
radar_client /Users/vanchi/harmony/code/radar_client/lib/radar_client.js:43
radar_client  info /Users/vanchi/harmony/code/radar_client/lib/radar_client.js:43 ready:  channel
radar_state debug /Users/vanchi/harmony/code/radar_client/lib/state.js:29 from connecting -> connected, event: established
radar_client /Users/vanchi/harmony/code/radar_client/lib/radar_client.js:280
radar_client debug /Users/vanchi/harmony/code/radar_client/lib/radar_client.js:280 ack {"message":{"op":"ack","value":1}}
radar_client /Users/vanchi/harmony/code/radar_client/lib/radar_client.js:522 nameSync message: {"op":"nameSync","to":"control:/test/clientName","options":{"association":{"name":"b9538713-b33b-4358-8eec-8946d3633cdd"},"clientVersion":"0.16.0"},"ack":1}
radar_client /Users/vanchi/harmony/code/radar_client/lib/radar_client.js:344
radar_client debug /Users/vanchi/harmony/code/radar_client/lib/radar_client.js:344 socket closed
radar_state debug /Users/vanchi/harmony/code/radar_client/lib/state.js:64 reconnecting in 255msec
radar_state debug /Users/vanchi/harmony/code/radar_client/lib/state.js:29 from activated -> disconnected, event: disconnect
radar_state debug /Users/vanchi/harmony/code/radar_client/lib/state.js:29 from disconnected -> connecting, event: connect
radar_state  info /Users/vanchi/harmony/code/radar_client/lib/state.js:108 startGuard: disconnect from timeout
radar_state debug /Users/vanchi/harmony/code/radar_client/lib/state.js:64 reconnecting in 390msec
radar_state debug /Users/vanchi/harmony/code/radar_client/lib/state.js:29 from connecting -> disconnected, event: disconnect
radar_client /Users/vanchi/harmony/code/radar_client/lib/radar_client.js:339
radar_client debug /Users/vanchi/harmony/code/radar_client/lib/radar_client.js:339 socket open
radar_state  warn /Users/vanchi/harmony/code/radar_client/lib/state.js:10 state-machine-error {"0":"established","1":"disconnected","2":"disconnected","3":[],"4":100,"5":"event established inappropriate in current state disconnected"}
radar_state debug /Users/vanchi/harmony/code/radar_client/lib/state.js:29 from disconnected -> connecting, event: connect
radar_client /Users/vanchi/harmony/code/radar_client/lib/radar_client.js:339
radar_client debug /Users/vanchi/harmony/code/radar_client/lib/radar_client.js:339 socket open
radar_state debug /Users/vanchi/harmony/code/radar_client/lib/state.js:29 from connected -> authenticating, event: authenticate
radar_state debug /Users/vanchi/harmony/code/radar_client/lib/state.js:29 from authenticating -> activated, event: activate
test /Users/vanchi/harmony/code/radar_client/tests/lib/engine.js:22 {"op":"nameSync","to":"control:/test/clientName","options":{"association":{"name":"b9538713-b33b-4358-8eec-8946d3633cdd"},"clientVersion":"0.16.0"},"ack":2}
radar_client /Users/vanchi/harmony/code/radar_client/lib/radar_client.js:456
radar_client debug /Users/vanchi/harmony/code/radar_client/lib/radar_client.js:456 restore-subscriptions {"subscriptions":0,"presences":0,"messages":0}
radar_state debug /Users/vanchi/harmony/code/radar_client/lib/state.js:29 from connecting -> connected, event: established
radar_client /Users/vanchi/harmony/code/radar_client/lib/radar_client.js:280
radar_client debug /Users/vanchi/harmony/code/radar_client/lib/radar_client.js:280 ack {"message":{"op":"ack","value":2}}
radar_client /Users/vanchi/harmony/code/radar_client/lib/radar_client.js:522 nameSync message: {"op":"nameSync","to":"control:/test/clientName","options":{"association":{"name":"b9538713-b33b-4358-8eec-8946d3633cdd"},"clientVersion":"0.16.0"},"ack":2}
    1) socket opening late should not cause two open sockets


  0 passing (1s)
  1 failing

  1) before connecting socket opening late should not cause two open sockets:

      Uncaught AssertionError: 2 == 1
      + expected - actual

      -2
      +1

      at null._onTimeout (tests/radar_client.connect.test.js:60:16)
```