### PR TITLE
Add support for custom state machine error handlers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - "0.10"
+  - "4.2"
 script: npm test && ./scripts/run_radar_tests
 notifications:
   flowdock:

--- a/lib/radar_client.js
+++ b/lib/radar_client.js
@@ -109,6 +109,10 @@ Client.prototype.configuration = function (configKey) {
   }
 }
 
+Client.prototype.attachStateMachineErrorHandler = function (errorHandler) {
+  this.manager.attachErrorHandler(errorHandler)
+}
+
 Client.prototype.currentUserId = function () {
   return this._configuration && this._configuration.userId
 }

--- a/lib/state.js
+++ b/lib/state.js
@@ -10,7 +10,11 @@ function create () {
       log.warn('state-machine-error', arguments)
 
       if (err) {
-        throw err
+        if (this.errorHandler) {
+          this.errorHandler(name, from, to, args, type, message, err)
+        } else {
+          throw err
+        }
       }
     },
 
@@ -126,6 +130,14 @@ function create () {
           machine.connectWhenAble()
         })
       }
+    }
+  }
+
+  machine.attachErrorHandler = function (errorHandler) {
+    if (typeof errorHandler === 'function') {
+      this.errorHandler = errorHandler
+    } else {
+      log.warn('errorHandler must be a function')
     }
   }
 

--- a/tests/radar_client.unit.test.js
+++ b/tests/radar_client.unit.test.js
@@ -1,4 +1,5 @@
 var assert = require('assert')
+var sinon = require('sinon')
 var RadarClient = require('../lib/radar_client.js')
 var MockEngine = require('./lib/engine.js')()
 var Request = require('radar_message').Request
@@ -99,6 +100,18 @@ exports.RadarClient = {
     'should store the passed hash as a configuration property': function () {
       client.configure({ accountName: 'test', userId: 123, userType: 2 })
       assert.deepEqual(client._configuration, { accountName: 'test', userId: 123, userType: 2 })
+    }
+  },
+
+  '.attachStateMachineErrorHandler': {
+    '.should attach error handler to the state manager': function () {
+      var errorHandler = function () {}
+      var attachErrorHandlerSpy = sinon.spy(client.manager, 'attachErrorHandler')
+
+      client.attachStateMachineErrorHandler(errorHandler)
+      assert.ok(attachErrorHandlerSpy.calledWith(errorHandler))
+
+      attachErrorHandlerSpy.restore()
     }
   },
 
@@ -651,14 +664,14 @@ exports.RadarClient = {
         'op': function () {
           var message = { to: 'status:/dev/ticket/1', value: 'x', time: new Date() / 1000 }
 
-          var response = new Response(message) // eslint-disable-line 
+          var response = new Response(message) // eslint-disable-line
           assert.deepEqual(client._channelSyncTimes, {})
         },
 
         'to': function () {
           var message = { op: 'subscribe', value: 'x', time: new Date() / 1000 }
 
-          var response = new Response(message) // eslint-disable-line 
+          var response = new Response(message) // eslint-disable-line
           assert.deepEqual(client._channelSyncTimes, {})
         },
 

--- a/tests/state.test.js
+++ b/tests/state.test.js
@@ -158,6 +158,37 @@ exports['given a state machine'] = {
     assert(machine._guard)
     machine.close()
     assert(!machine._guard)
+  },
+
+  'should be able to attach a custom errorHandler': function () {
+    var handler = function () {}
+    machine.attachErrorHandler(handler)
+    assert.equal(machine.errorHandler, handler)
+  },
+
+  'should be able to override the custom errorHandler': function () {
+    var handler1 = function () {}
+    var handler2 = function () {}
+
+    machine.attachErrorHandler(handler1)
+    machine.attachErrorHandler(handler2)
+    assert.equal(machine.errorHandler, handler2)
+  },
+
+  'should only allow attaching a function as a custom state machine error handler': function () {
+    assert(!machine.errorHandler)
+
+    machine.attachErrorHandler(23)
+    assert(!machine.errorHandler)
+
+    machine.attachErrorHandler({})
+    assert(!machine.errorHandler)
+
+    machine.attachErrorHandler('error')
+    assert(!machine.errorHandler)
+
+    machine.attachErrorHandler(function () {})
+    assert(machine.errorHandler)
   }
 }
 


### PR DESCRIPTION
This adds support for custom state machine error handlers. Therefore one may define their own error handler to use instead of the default one provided by the state machine. This PR maintains backwards compatibility.