### PR TITLE
[ROLLBAR-11641] Fix JS error if socket close before we process activate event

### DIFF
--- a/dist/radar_client.js
+++ b/dist/radar_client.js
@@ -584,7 +584,7 @@ var RadarClient =
 	}
 
 	Client.prototype._identitySet = function () {
-	  if (this._identitySetRequired) {
+	  if (this._identitySetRequired && this._socket) {
 	    this._identitySetRequired = false
 
 	    if (!this.name) {

--- a/lib/radar_client.js
+++ b/lib/radar_client.js
@@ -521,7 +521,7 @@ Client.prototype.emitNext = function () {
 }
 
 Client.prototype._identitySet = function () {
-  if (this._identitySetRequired) {
+  if (this._identitySetRequired && this._socket) {
     this._identitySetRequired = false
 
     if (!this.name) {


### PR DESCRIPTION
The following JS error coming from radar-client is on the top 10 of Rollbar error for lotus:

```
TypeError: Cannot read property 'id' of null

File https://p14.zdassets.com/agent/assets/vendor-ab151b35535fbd9e854bafae066c0c79.js line 36 col 25082 in r._identitySet
File https://p14.zdassets.com/agent/assets/vendor-ab151b35535fbd9e854bafae066c0c79.js line 36 col 22817 in Object.<anonymous>
File https://p14.zdassets.com/agent/assets/vendor-ab151b35535fbd9e854bafae066c0c79.js line 36 col 26330 in Object.emit
File https://p14.zdassets.com/agent/assets/vendor-ab151b35535fbd9e854bafae066c0c79.js line 37 col 28062 in Object.onevent
File https://p14.zdassets.com/agent/assets/vendor-ab151b35535fbd9e854bafae066c0c79.js line 37 col 31006 in Object.doCallback
File https://p14.zdassets.com/agent/assets/vendor-ab151b35535fbd9e854bafae066c0c79.js line 37 col 31284 in Object.afterAnyEvent
File https://p14.zdassets.com/agent/assets/vendor-ab151b35535fbd9e854bafae066c0c79.js line 38 col 143 in Object.afterEvent
File https://p14.zdassets.com/agent/assets/vendor-ab151b35535fbd9e854bafae066c0c79.js line 38 col 899 in Object.activate
File https://p14.zdassets.com/agent/assets/vendor-ab151b35535fbd9e854bafae066c0c79.js line 37 col 28869 in Object.t.start
File https://p14.zdassets.com/agent/assets/vendor-ab151b35535fbd9e854bafae066c0c79.js line 36 col 18854 in r.alloc
```
Looks like if the socket connection is dropped right after a connection, we can still get an `activate` event and in that case, we will try to access the socket object despite it's null.

The proposed fix is to skip doing `_identitySet` if we do not have a socket. Next time the socket open, `_identitySet` will be called again.

## References
- ROLLBAR: [#11641](https://rollbar-us.zendesk.com/Zendesk/Lotus/items/11641)

## Risks
- Low, the client might not identify itself properly