### PR TITLE
[Rollbar-24863]: Use sockeId to determine connection is properly established

### DIFF
--- a/lib/radar_client.js
+++ b/lib/radar_client.js
@@ -389,12 +389,11 @@ Client.prototype._createManager = function () {
   })
 
   manager.on('activate', function () {
-    if (self._socket === null) {
-      manager.disconnect()
-    } else {
-      self._identitySet()
+    if(self._identitySet()) {
       self._restore()
       self.emit('ready')
+    } else {
+      manager.disconnect()
     }
   })
 
@@ -545,6 +544,7 @@ Client.prototype.emitNext = function () {
 }
 
 Client.prototype._identitySet = function () {
+
   if (this._identitySetRequired) {
     this._identitySetRequired = false
 
@@ -552,8 +552,14 @@ Client.prototype._identitySet = function () {
       this.name = this._uuidV4Generate()
     }
 
+    var socketId = this.currentClientId()
+
     // Send msg that associates this.id with current name
-    var association = { id: this._socket.id, name: this.name }
+    if (!socketId) {
+      return false
+    }
+
+    var association = { id: socketId, name: this.name }
     var clientVersion = getClientVersion()
     var options = { association: association, clientVersion: clientVersion }
     var self = this
@@ -561,6 +567,8 @@ Client.prototype._identitySet = function () {
     this.control('clientName').nameSync(options, function (message) {
       self.logger('nameSync message: ' + JSON.stringify(message))
     })
+
+    return true
   }
 }
 


### PR DESCRIPTION
https://rollbar-us.zendesk.com/Zendesk/Lotus/items/24863/


This PR tries to resolve the situation when `this._socket` is null by using `currentClientId` method and also early return if there is no socket to disconnect.