### PR TITLE
Use engine.io-client with polling XHR timeouts.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "radar_client",
   "description": "Realtime apps with a high level API based on engine.io",
-  "version": "0.16.2",
+  "version": "0.16.3",
   "license": "Apache-2.0",
   "author": "Zendesk, Inc.",
   "contributors": [
@@ -32,11 +32,11 @@
     "url": "https://github.com/zendesk/radar_client.git"
   },
   "dependencies": {
+    "engine.io-client": "zendesk/engine.io-client#hhsu/1.4.2-xhr-polling-timeout",
     "microee": "*",
     "minilog": "*",
-    "engine.io-client": "1.4.2",
-    "sfsm": "0.0.4",
-    "radar_message": "^1.0.1"
+    "radar_message": "^1.0.1",
+    "sfsm": "0.0.4"
   },
   "devDependencies": {
     "gulp": "^3.9.1",


### PR DESCRIPTION
This uses a [patched version of `engine.io-client`](https://github.com/socketio/engine.io-client/compare/1.4.2...zendesk:hhsu/1.4.2-xhr-polling-timeout) which allows clients to set the XHR timeout.

It is loosely based on [this upstream commit](https://github.com/socketio/engine.io-client/commit/3427e744e1c8fcd397dcbb72ea65638ca101d988) to engine.io-client.

This allows the `requestTimeout` param set in the `RadarClient.configure` to flow through to the XHR polling socket. https://github.com/zendesk/radar_client/blob/master/lib/radar_client.js#L340