### PR TITLE
Emit event when there is a socket error.

### DIFF
--- a/dist/radar_client.js
+++ b/dist/radar_client.js
@@ -445,6 +445,10 @@ var RadarClient =
 	      self._messageReceived(message)
 	    })
 
+	    socket.on('error', function (error) {
+	      self.emit('socketError', error)
+	    })
+
 	    manager.removeAllListeners('close')
 	    manager.once('close', function () {
 	      socket.close()
@@ -1132,7 +1136,7 @@ var RadarClient =
 
 	// Auto-generated file, overwritten by scripts/add_package_version.js
 
-	function getClientVersion () { return '0.16.3' }
+	function getClientVersion () { return '0.16.4' }
 
 	module.exports = getClientVersion
 

--- a/lib/client_version.js
+++ b/lib/client_version.js
@@ -1,5 +1,5 @@
 // Auto-generated file, overwritten by scripts/add_package_version.js
 
-function getClientVersion () { return '0.16.3' }
+function getClientVersion () { return '0.16.4' }
 
 module.exports = getClientVersion

--- a/lib/radar_client.js
+++ b/lib/radar_client.js
@@ -382,6 +382,10 @@ Client.prototype._createManager = function () {
       self._messageReceived(message)
     })
 
+    socket.on('error', function (error) {
+      self.emit('socketError', error)
+    })
+
     manager.removeAllListeners('close')
     manager.once('close', function () {
       socket.close()

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "radar_client",
   "description": "Realtime apps with a high level API based on engine.io",
-  "version": "0.16.3",
+  "version": "0.16.4",
   "license": "Apache-2.0",
   "author": "Zendesk, Inc.",
   "contributors": [


### PR DESCRIPTION
In light of https://github.com/zendesk/radar_client/pull/79, it would be good to track when a socket error has happened (whether it was due to a timeout or not).