### PR TITLE
Fixes issue where the state machine infinitely disconnects when starting in a bad state.

### DIFF
--- a/dist/radar_client.js
+++ b/dist/radar_client.js
@@ -787,12 +787,8 @@ var RadarClient =
 	      },
 
 	      onstate: function (event, from, to) {
-	        var self = this
-	        var args = Array.prototype.slice.call(arguments)
-	        setImmediate(function () {
-	          self.emit('enterState', to)
-	          self.emit(to, args)
-	        })
+	        this.emit('enterState', to)
+	        this.emit(to, arguments)
 	      },
 
 	      onconnecting: function () {
@@ -878,10 +874,13 @@ var RadarClient =
 	  machine.connectWhenAble = function () {
 	    if (!(this.is('connected') || this.is('activated'))) {
 	      if (this.can('connect')) {
-	        this.connect()
+	        // Don't connect if we are waiting to reconnect
+	        if (!machine._timer) {
+	          this.connect()
+	        }
 	      } else {
 	        this.once('enterState', function () {
-	          machine.connectWhenAble()
+	          setImmediate(function () { machine.connectWhenAble() })
 	        })
 	      }
 	    }
@@ -1140,7 +1139,7 @@ var RadarClient =
 
 	// Auto-generated file, overwritten by scripts/add_package_version.js
 
-	function getClientVersion () { return '0.16.4' }
+	function getClientVersion () { return '0.16.5' }
 
 	module.exports = getClientVersion
 

--- a/dist/radar_client.js
+++ b/dist/radar_client.js
@@ -787,8 +787,12 @@ var RadarClient =
 	      },
 
 	      onstate: function (event, from, to) {
-	        this.emit('enterState', to)
-	        this.emit(to, arguments)
+	        var self = this
+	        var args = Array.prototype.slice.call(arguments)
+	        setImmediate(function () {
+	          self.emit('enterState', to)
+	          self.emit(to, args)
+	        })
 	      },
 
 	      onconnecting: function () {

--- a/lib/client_version.js
+++ b/lib/client_version.js
@@ -1,5 +1,5 @@
 // Auto-generated file, overwritten by scripts/add_package_version.js
 
-function getClientVersion () { return '0.16.4' }
+function getClientVersion () { return '0.16.5' }
 
 module.exports = getClientVersion

--- a/lib/state.js
+++ b/lib/state.js
@@ -37,8 +37,12 @@ function create () {
       },
 
       onstate: function (event, from, to) {
-        this.emit('enterState', to)
-        this.emit(to, arguments)
+        var self = this
+        var args = Array.prototype.slice.call(arguments)
+        setImmediate(function () {
+          self.emit('enterState', to)
+          self.emit(to, args)
+        })
       },
 
       onconnecting: function () {

--- a/lib/state.js
+++ b/lib/state.js
@@ -37,12 +37,8 @@ function create () {
       },
 
       onstate: function (event, from, to) {
-        var self = this
-        var args = Array.prototype.slice.call(arguments)
-        setImmediate(function () {
-          self.emit('enterState', to)
-          self.emit(to, args)
-        })
+        this.emit('enterState', to)
+        this.emit(to, arguments)
       },
 
       onconnecting: function () {
@@ -128,10 +124,13 @@ function create () {
   machine.connectWhenAble = function () {
     if (!(this.is('connected') || this.is('activated'))) {
       if (this.can('connect')) {
-        this.connect()
+        // Don't connect if we are waiting to reconnect
+        if (!machine._timer) {
+          this.connect()
+        }
       } else {
         this.once('enterState', function () {
-          machine.connectWhenAble()
+          setImmediate(function () { machine.connectWhenAble() })
         })
       }
     }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "radar_client",
   "description": "Realtime apps with a high level API based on engine.io",
-  "version": "0.16.4",
+  "version": "0.16.5",
   "license": "Apache-2.0",
   "author": "Zendesk, Inc.",
   "contributors": [

--- a/tests/radar_client.test.js
+++ b/tests/radar_client.test.js
@@ -72,7 +72,12 @@ exports['after reconnecting'] = {
   },
 
   'should send queued messages': function (done) {
+    var connecting = false
     var connected = false
+
+    client.once('connecting', function () {
+      connecting = true
+    })
 
     client.once('connect', function () {
       connected = true
@@ -89,6 +94,7 @@ exports['after reconnecting'] = {
     })
 
     client.once('ready', function () {
+      assert.ok(connecting)
       assert.ok(connected)
       assert.equal(client._queuedRequests.length, 0)
       assert.ok(
@@ -104,7 +110,6 @@ exports['after reconnecting'] = {
     client.manager.disconnect()
     assert.equal(client.currentState(), 'disconnected')
     client.status('tickets/21').set('online')
-    assert.equal(client.currentState(), 'connecting')
   },
 
   'should resend queued presences': function (done) {


### PR DESCRIPTION
### Reproduction Steps


1. Open a page with a working Radar connection (in development).
2. In the JavaScript console of Chrome, run `Minilog.enable()` to see `radar_state` logs.
3. Notice the following `radar_state` logs:
```
14:53:09.852 minilog.js:447 radar_state from none -> opened, event: open
14:53:12.673 minilog.js:447 radar_state from opened -> connecting, event: connect
14:53:12.723 minilog.js:447 radar_state from connected -> authenticating, event: authenticate
14:53:12.727 minilog.js:447 radar_state from connecting -> connected, event: established
14:53:12.780 minilog.js:447 radar_state from authenticating -> activated, event: activate
```
4. Kill the Radar server (in development). Refresh the browser. Then restart the Radar server.
5. Notice the following `radar_state` logs:
```
14:54:39.910 minilog.js:447 radar_state from opened -> connecting, event: connect
14:54:40.032 minilog.js:447 radar_state reconnecting in 5800msec
14:54:40.033 minilog.js:447 radar_state from disconnected -> connecting, event: connect
14:54:40.037 minilog.js:447 radar_state from connecting -> disconnected, event: disconnect
14:54:50.034 minilog.js:449 radar_state startGuard: disconnect from timeout
14:54:50.035 minilog.js:447 radar_state reconnecting in 2885msec
14:54:50.036 minilog.js:447 radar_state from disconnected -> connecting, event: connect
14:54:50.041 minilog.js:447 radar_state from connecting -> disconnected, event: disconnect
14:55:00.040 minilog.js:449 radar_state startGuard: disconnect from timeout
14:55:00.041 minilog.js:447 radar_state reconnecting in 7168msec
14:55:00.042 minilog.js:447 radar_state from disconnected -> connecting, event: connect
14:55:00.046 minilog.js:447 radar_state from connecting -> disconnected, event: disconnect
14:55:10.044 minilog.js:449 radar_state startGuard: disconnect from timeout
14:55:10.046 minilog.js:447 radar_state reconnecting in 9145msec
14:55:10.047 minilog.js:447 radar_state from disconnected -> connecting, event: connect
14:55:10.056 minilog.js:447 radar_state from connecting -> disconnected, event: disconnect
```

Where the Radar client will connect and then immediately disconnect indefinitely.

### Explanation of Fix

Here's what's happening:

1. Because Radar isn't reachable the first time the browser starts, it invokes this [guard](https://github.com/zendesk/radar_client/blob/master/lib/state.js#L111).
2. When that timeout fires, it invokes [`machine.disconnect`](https://github.com/zendesk/radar_client/blob/master/lib/state.js#L113)
3. That immediately invokes the [`enterState` event](https://github.com/zendesk/radar_client/blob/master/lib/state.js#L40)
4. Which then invokes [`machine.connectWhenAble()`](https://github.com/zendesk/radar_client/blob/master/lib/state.js#L130)
5. And then [`machine.connect()`](https://github.com/zendesk/radar_client/blob/master/lib/state.js#L127)
6. And *then* the event for `machine.disconnect()` (from 2) is triggered.
7. Which triggers [this callback](https://github.com/zendesk/radar_client/blob/621b73cbfb7a4cc2b8ec3e18078fe43945e10bde/lib/radar_client.js#L411)
8. Which causes us to [close the socket once it's opened](https://github.com/zendesk/radar_client/blob/621b73cbfb7a4cc2b8ec3e18078fe43945e10bde/lib/radar_client.js#L425)
9. And then this deadly loop repeats

The reason the `enterState` behaves this way is grokkable [here](https://github.com/4031651/node-javascript-state-machine/blob/master/state-machine.js#L163).

### The Fix

To fix this, we defer the `enterState` event until the next tick. That way, the `disconnect` will run first and then the `connect` event will follow unhindered.