### PR TITLE
[SILK-1415] after backoff, reconnect if the state is connecting

### DIFF
--- a/lib/state.js
+++ b/lib/state.js
@@ -69,7 +69,7 @@ function create () {
 
         this._timer = setTimeout(function () {
           delete machine._timer
-          if (machine.is('disconnected')) {
+          if (machine.is('disconnected') || machine.is('connecting')) {
             machine.connect()
           }
         }, time)
@@ -110,7 +110,7 @@ function create () {
     machine.cancelGuard()
     machine._guard = setTimeout(function () {
       log.info('startGuard: disconnect from timeout')
-      machine.disconnect()
+      machine.connect()
     }, machine._connectTimeout)
   }
 


### PR DESCRIPTION
### Description

if radar met some network issue, the state is not converted to disconnected yet, and  after backoff, it sends unavailable. 
Adding a connect action when transition state is connecting.

### References

* [Jira](https://zendesk.atlassian.net/browse/SILK-1415):
* Github issue:

### Risks

* Medium : As this may cause a spike at connection times in radar
* Rollback:

