### PR TITLE
Add Claude Code GitHub Actions

### DIFF
--- a/.github/workflows/claude-auto-review.yml
+++ b/.github/workflows/claude-auto-review.yml
@@ -1,0 +1,47 @@
+name: Claude Auto Review
+
+on:
+  pull_request:
+    types: [opened, ready_for_review]
+
+jobs:
+  auto-review:
+    if: github.event.pull_request.draft == false
+    runs-on: [ self-hosted, zendesk-stable ]
+    permissions:
+      contents: write
+      pull-requests: write
+      id-token: write
+      actions: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Automatic PR Review
+        uses: anthropics/claude-code-action@beta
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          use_bedrock: true
+          direct_prompt: |
+            Review this PR briefly and only leave comments for issues that
+            require changes before merge (correctness, security, performance with evidence,
+            missing/incorrect tests, required docs). Do not leave style/nit comments.
+            NO NEED to comment what have been doing well in the PR, focus on what need to be changed.
+
+            Do not repeat items that have already been addressed or previously commented.
+            If an earlier issue is now resolved, say nothing about it.
+            For follow-up pushes, only comment on NEW blocking issues introduced by the latest changes.
+
+            Keep each comment to one line with a concrete fix suggestion when possible.
+        env:
+          CLAUDE_CODE_USE_BEDROCK: true
+          CLAUDE_CODE_SKIP_BEDROCK_AUTH: true
+          ANTHROPIC_MODEL: us.anthropic.claude-sonnet-4-20250514-v1:0
+          ANTHROPIC_BEDROCK_BASE_URL: https://ai-gateway.zende.sk/bedrock
+          ANTHROPIC_AUTH_TOKEN: ${{ secrets.ANTHROPIC_API_TOKEN }}
+
+          # To bypass the validation script, which just checks to see if they exist
+          # https://zendesk.slack.com/archives/C05Q3UJCG14/p1755763610577519?thread_ts=1755742180.499569&cid=C05Q3UJCG14
+          AWS_REGION: "us-east-1"
+          AWS_ACCESS_KEY_ID: "fake"
+          AWS_SECRET_ACCESS_KEY: "fake"

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,93 @@
+name: Claude PR Assistant
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  issues:
+    types: [opened, assigned]
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  claude-review-action:
+    if: github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude review')
+    runs-on: [ self-hosted, zendesk-stable ]
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
+      actions: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude PR Review
+        uses: anthropics/claude-code-action@beta
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          use_bedrock: true
+          direct_prompt: |
+            Review this PR briefly and only leave comments for issues that
+            require changes before merge (correctness, security, performance with evidence,
+            missing/incorrect tests, required docs). Do not leave style/nit comments.
+            NO NEED to comment what have been doing well in the PR, focus on what need to be changed.
+
+            Do not repeat items that have already been addressed or previously commented.
+            If an earlier issue is now resolved, say nothing about it.
+            For follow-up pushes, only comment on NEW blocking issues introduced by the latest changes.
+
+            Keep each comment to one line with a concrete fix suggestion when possible.
+        env:
+          CLAUDE_CODE_USE_BEDROCK: true
+          CLAUDE_CODE_SKIP_BEDROCK_AUTH: true
+          ANTHROPIC_MODEL: us.anthropic.claude-sonnet-4-20250514-v1:0
+          ANTHROPIC_BEDROCK_BASE_URL: https://ai-gateway.zende.sk/bedrock
+          ANTHROPIC_AUTH_TOKEN: ${{ secrets.ANTHROPIC_API_TOKEN }}
+
+          # To bypass the validation script, which just checks to see if they exist
+          # https://zendesk.slack.com/archives/C05Q3UJCG14/p1755763610577519?thread_ts=1755742180.499569&cid=C05Q3UJCG14
+          AWS_REGION: "us-east-1"
+          AWS_ACCESS_KEY_ID: "fake"
+          AWS_SECRET_ACCESS_KEY: "fake"
+
+  claude-code-action:
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude') && !contains(github.event.comment.body, '@claude review')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+      (github.event_name == 'issues' && contains(github.event.issue.body, '@claude'))
+    runs-on: [ self-hosted, zendesk-stable ]
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
+      actions: write # Required for Claude to read CI results on PRs
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Run Claude PR Action
+        uses: anthropics/claude-code-action@beta
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          use_bedrock: true
+          custom_instructions: |
+            Be concise and focus only on sharing new information the user doesn't already know. Avoid mentioning what has been done well or what has already been completed. Provide direct, actionable insights without unnecessary explanations.
+        env:
+          CLAUDE_CODE_USE_BEDROCK: true
+          CLAUDE_CODE_SKIP_BEDROCK_AUTH: true
+          ANTHROPIC_MODEL: us.anthropic.claude-sonnet-4-20250514-v1:0
+          ANTHROPIC_BEDROCK_BASE_URL: https://ai-gateway.zende.sk/bedrock
+          ANTHROPIC_AUTH_TOKEN: ${{ secrets.ANTHROPIC_API_TOKEN }}
+
+          # To bypass the validation script, which just checks to see if they exist
+          # https://zendesk.slack.com/archives/C05Q3UJCG14/p1755763610577519?thread_ts=1755742180.499569&cid=C05Q3UJCG14
+          AWS_REGION: "us-east-1"
+          AWS_ACCESS_KEY_ID: "fake"
+          AWS_SECRET_ACCESS_KEY: "fake"


### PR DESCRIPTION
## Summary
Adds Claude Code GitHub Actions for automated PR reviews, matching the configuration in the ask repo.

## Changes
- Added `.github/workflows/claude.yml` - Enables manual Claude reviews via @claude mentions
- Added `.github/workflows/claude-auto-review.yml` - Automatic reviews on PR open/ready for review

## Configuration
- Uses Bedrock with Sonnet 4 model via Zendesk AI Gateway
- Runs on self-hosted zendesk-stable runners
- Follows same patterns as other Compass team repos (ask, actor-management-service, etc.)

## Testing
This is a draft PR for review. Once approved, Claude will be available for:
- Manual reviews: Comment `@claude review` on any PR
- Automatic reviews: New PRs marked ready for review
- Interactive assistance: Comment `@claude <question>` for help