### PR TITLE
Fix insecure HTTP link to HTTPS in documentation

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -8,7 +8,7 @@ The radar server code is here: https://github.com/zendesk/radar
 
 ## Documentation
 
-See http://radar.zendesk.com/ for detailed documentation.
+See https://radar.zendesk.com/ for detailed documentation.
 
 ## How to contribute
 


### PR DESCRIPTION
Small fix — updates the documentation link from http to https.